### PR TITLE
fix: number of cluster centers in init_Mu

### DIFF
--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -187,6 +187,10 @@ class KmeansNANI{
             centers = data(idx,Eigen::all);
             break;
         }
+        // only take first kClusters centers
+        if (centers.rows() > kClusters){
+            centers = centers(Eigen::seq(0, kClusters-1), Eigen::all).eval();
+        }
     }
 
     // ======================================================= Update Assignments Z


### PR DESCRIPTION
This pull request adds a safeguard to the logic for selecting cluster centers in the `KmeansNANI` class to ensure that only the first `kClusters` centers are used, even if more are available.

Cluster center selection:

* In `KMeans.cpp`, after initializing the centers, the code now checks if the number of selected centers exceeds `kClusters` and, if so, truncates the centers to use only the first `kClusters` rows.