### PR TITLE
maint: add overflow check to msdCondensed

### DIFF
--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -45,7 +45,12 @@ double msdCondensed(ArrayXd& cSum, ArrayXd& sqSum, Index N, int nAtoms){
     if (nAtoms <= 0) {
         throw std::invalid_argument("nAtoms must be positive and non-zero.");
     }
-    return (double)2.0 * (sqSum * N - cSum.square()).sum() / (N * N * nAtoms);
+    if (N > 46340){
+        return (double)2.0 * (sqSum * N - cSum.square()).sum() / ((double)N * N * nAtoms);
+    }
+    else{
+        return (double)2.0 * (sqSum * N - cSum.square()).sum() / (N * N * nAtoms);
+    }
 }
 
 /* O(N) Extended comparison function for n-ary objects.


### PR DESCRIPTION
Added the suggestion of [issue 3](https://github.com/pyukey/CPP-MDANCE/issues/3). 
This introduces a conditional branch in the `msdCondensed` function to handle cases where the value of `N` is greater than 46,340. This change ensures that the calculation uses explicit type casting for large values of `N`, which can help prevent integer overflow and maintain numerical accuracy.