### PR TITLE
perf: remove redundant square in for loop

### DIFF
--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -129,10 +129,9 @@ ArrayXd calculateCompSim(ArrayXXd& data, int nAtoms, MD::Metric mt) {
         compSims = (2 * (compSq - compC.square())/ nAtoms).rowwise().sum();
     } else {
         for (int i=0; i<N; ++i){
-            ArrayXd objSq = data.row(i).square();
             ArrayXXd compData (2,data.cols());
             compData.row(0) = cSum.transpose() - data.row(i);
-            compData.row(1) = sqSum - objSq;
+            compData.row(1) = sqSum - sqData.row(i);
             compSims[i] = extendedComparison(compData, N-1, nAtoms, true, mt);
         }
     }


### PR DESCRIPTION
This pull request includes a minor update to the calculation logic in the `calculateCompSim` function. The change improves code clarity and consistency by replacing the local variable `objSq` with the already computed `sqData.row(i)` in the comparison calculation. This change addresses [issue 9](https://github.com/pyukey/CPP-MDANCE/issues/9) in the old repository. 