### PR TITLE
feat: add z-matrix evaluation

### DIFF
--- a/src/cluster/helm.cpp
+++ b/src/cluster/helm.cpp
@@ -399,12 +399,6 @@ class Helm{
         return clusters;
     }
 
-    void zMatrix(map<int, vector<vector<Cluster>>>& clusterMap){
-        /*
-            Converts the cluster dictionary to a linkage matrix for plotting dendogram
-        */
-    }
-
     public:
         Helm(map<int, vector<Cluster>> clusterMap, int nAtoms, MD::Metric mt = MD::Metric::MSD, 
                 MD::MergeScheme mergeScheme = MD::MergeScheme::Inter, int nClusters = 0, float eps = -1, 
@@ -545,5 +539,76 @@ class Helm{
                 return pair<double, double>{chScore, dbScore};
             }
         };
+
+        Mat calculateZMatrix(map<int, vector<Cluster>> clusterMap){
+            /* 
+                Converts the cluster dictionary to a linkage matrix Z
+
+                Returns
+                -------------
+                Z matrix (Mat)
+            */
+            vector<Veci> indices_clusters; // contains all unique clusters, and merged clusters
+            vector<Cluster> initial_clusters = clusterMap.rbegin()->second;
+            for (int i = 0; i < initial_clusters.size(); i++) {
+                indices_clusters.push_back(initial_clusters[i].getIndices());
+            }
+
+            Mat zMatrix(clusterMap.size()-1, 4);
+            int row = 0;
+            
+            // iterate through clusterMap in reverse order to get merging order
+            // clusterMap is sorted by keys (No. clusters) in ascending order, thus we must traverse it in reverse
+            for(auto it = clusterMap.rbegin(); it != clusterMap.rend(); ++it){
+                vector<Cluster> current_clusters = it->second;
+                for (auto cluster : current_clusters){
+                    // convert vector to set so that it is easier to compare them
+                    Veci inds = cluster.getIndices();
+                    std::set inds_set(std::begin(inds), std::end(inds));
+                    if (inds.size() != inds_set.size()){
+                        throw std::runtime_error("indices of current cluster has duplicate members!");
+                    }
+                    // check if this cluster already exists in indices_clusters. This means it is not a new merged cluster
+                    bool found = false;
+                    for (int i = 0; i < indices_clusters.size(); i++){
+                        Veci ind_prev_cluster = indices_clusters[i];
+                        std::set<int> ind_prev_cluster_set(std::begin(ind_prev_cluster), std::end(ind_prev_cluster));
+
+                        if (ind_prev_cluster.size() != ind_prev_cluster_set.size()){
+                            throw std::runtime_error("indices of cluster has duplicate members!");
+                        }
+                        if (ind_prev_cluster_set == inds_set){
+                            found = true;
+                            break;
+                        }
+                    }
+                    // extract data for Z matrix for the merged cluster
+                    if (!found){
+                        for (int i = 0; i < indices_clusters.size(); i++){
+                            for (int j = i+1; j < indices_clusters.size(); j++){
+                                Veci ind_i = indices_clusters[i];
+                                Veci ind_j = indices_clusters[j];
+                                set<int> set_i(std::begin(ind_i), std::end(ind_i));
+                                set<int> set_j(std::begin(ind_j), std::end(ind_j));
+                                set<int> set_union_ij;
+                                std::set_union(set_i.begin(), set_i.end(), set_j.begin(), set_j.end(), std::inserter(set_union_ij, set_union_ij.begin()));
+                                if (set_union_ij == inds_set){
+                                    // found two clusters being merged
+                                    zMatrix(row, 0) = i; // index of first cluster being merged
+                                    zMatrix(row, 1) = j; // index of second cluster being merged
+                                    zMatrix(row, 2) = row+1; // "distance" between clusters (using row number as proxy)
+                                    zMatrix(row, 3) = inds_set.size(); // number of cluster members
+                                    row +=1;
+                                    break;
+                                }
+                            }
+                        }
+                        indices_clusters.push_back(inds); // add new merged cluster to list
+                    }
+                }
+                // fixme: there are no checks to ensure that there is only one new merged cluster per iteration! 
+        }
+        return zMatrix;
+    };
 };
 

--- a/tests/test_helm.cpp
+++ b/tests/test_helm.cpp
@@ -416,3 +416,46 @@ TEST_F(TestHelm, TestTrimVal){
         EXPECT_LT(msds[i], 5);
     }
 }
+
+TEST_F(TestHelm, ZMatrix){
+    int nAtoms = 50;
+    int nClus = 37;
+    Helm helm = Helm(clusters_map,
+        nAtoms, 
+        MD::Metric::MSD, 
+        MD::MergeScheme::Inter, 
+        nClus
+    );
+    map<int, vector<Cluster>> clusters = helm.run();
+    Mat Z = helm.calculateZMatrix(clusters);
+    Mat expectedZ(23, 4);
+    expectedZ <<2, 23, 1.0, 2, 
+        47, 60, 2.0, 3, 
+        15, 31, 3.0, 2, 
+        22, 45, 4.0, 2, 
+        5, 55, 5.0, 2, 
+        26, 34, 6.0, 2, 
+        9, 41, 7.0, 2, 
+        14, 27, 8.0, 2, 
+        4, 17, 9.0, 2, 
+        8, 62, 10.0, 3, 
+        0, 11, 11.0, 2, 
+        3, 6, 12.0, 2, 
+        19, 25, 13.0, 2, 
+        57, 63, 14.0, 3, 
+        35, 52, 15.0, 2, 
+        18, 64, 16.0, 3, 
+        20, 42, 17.0, 2, 
+        16, 68, 18.0, 3, 
+        66, 75, 19.0, 5, 
+        1, 72, 20.0, 3, 
+        21, 65, 21.0, 3, 
+        36, 40, 22.0, 2, 
+        51, 56, 23.0, 2;
+    for(int i=0; i<expectedZ.rows(); i++){
+        for(int j=0; j<4; j++){
+            EXPECT_EQ(Z(i,j), expectedZ(i,j));
+        }
+    }
+        
+}


### PR DESCRIPTION
This pull request introduces a new method to generate a hierarchical clustering linkage matrix (Z-matrix) from cluster data and adds a corresponding unit test to verify its correctness. The main changes include the implementation of the `calculateZMatrix` method in the `Helm` class and a new test case to ensure its output matches expectations.

@vicciv1623 tagging you here so you are aware of the changes/implementation. 