### PR TITLE
Bugfixes and hardening: UB fixes, BTS repairs, HELM leak fix, build/test/CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: build-and-test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev libgtest-dev
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,5 +13,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG" CACHE STRING "Release flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -DNDEBUG" CACHE STRING "RelWithDebInfo flags" FORCE)
 
+# Enable testing at the top level so `ctest` run from the build root discovers
+# the tests registered in subdirectories (must precede add_subdirectory).
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(MDance VERSION 1.0 LANGUAGES CXX)
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Build type" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
 endif()
 
 # Compiler flags for different build types

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ A c++ implementation of MDANCE, a flexible n-ary clustering package for all appl
 
 ## Getting Started with MDance
 
-Before you begin, make sure you have **Eigen** installed.
+Before you begin, make sure you have:
+- **Eigen** >= 3.4 (the code uses the Eigen 3.4 slicing API)
+- **GoogleTest** (only needed to build the test suite)
+- **CMake** >= 3.15 and a C++17 compiler
 
 ### Step 1: get source code
 
@@ -35,12 +38,9 @@ Compile MDance by running:
 cmake --build build
 ```
 ### Step 4: Run Tests
-Navigate to `build/tests/` folder:
+Use `ctest` from the build directory to execute the tests:
 ```shell
-cd build/tests/
-```
-Use `ctest` to execute the tests:
-```shell
+cd build
 ctest
 ```
 An example output is:
@@ -56,9 +56,8 @@ Total Test time (real) =   2.71 sec
 <span style="color:red">TODO:</span> add instructions for installation and figure out how to make CPP-MDANCE easily portable.
 
 ## Important files
-- `src/cluster/KmeansRex/KmeansRexCore.cpp`: Has **NANI** implementation
+- `src/cluster/KMeansRex/KMeans.cpp`: Has the **NANI** implementation (adapted from KMeansRex)
+- `src/cluster/helm.cpp`: Has the **HELM** implementation
 - `src/tools`: Has supporting functions, such as BTS, type definitions, and score calculations.
-- <span style="color:red">TODO:</span> implement HELM
-- `tests/runTests.sh`: Bash script for testing code by comoparing output to that of the Python library
-   - `tests/data`: stores datasets
-   - `tests/results`: Stores the results of the test. The results themselves are stored in the `*Results.txt` files, while the time and any error messages are stored in `*Time.txt` files
+- `tests`: GoogleTest suite comparing the output against the Python MDANCE library
+   - `tests/data`: stores the datasets used by the tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,19 +2,21 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_language(C CXX)
 
-find_package(Eigen3 3.3 REQUIRED)
+# The code uses the Eigen 3.4 slicing API (Eigen::all, Eigen::seq), so 3.3 is
+# not enough even though it used to configure successfully.
+find_package(Eigen3 3.4 REQUIRED)
 
 # Create library for tools
 add_library(mdance_tools STATIC
-    tools/bts.cpp 
-    tools/cluster.cpp 
+    tools/bts.cpp
+    tools/cluster.cpp
     tools/hc_utils.cpp
-    tools/esim.cpp 
+    tools/esim.cpp
     tools/scores.cpp
 )
-target_include_directories(mdance_tools PUBLIC 
-    tools
-    ${EIGEN3_INCLUDE_DIRS})
+target_include_directories(mdance_tools PUBLIC
+    tools)
+target_link_libraries(mdance_tools PUBLIC Eigen3::Eigen)
 
 # create library for kmeans
 add_library(mdance_kmeans STATIC 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,44 @@ enable_language(C CXX)
 
 # The code uses the Eigen 3.4 slicing API (Eigen::all, Eigen::seq), so 3.3 is
 # not enough even though it used to configure successfully.
-find_package(Eigen3 3.4 REQUIRED)
+#
+# Asking for 3.4 is still not sufficient on its own: Eigen's config file
+# declares SameMajorVersion compatibility, so a 3.4 request is REJECTED by
+# Eigen 5.x even though the code builds and passes against it. Ask for the real
+# floor first, so a 3.x install is still held to it, then fall back to whatever
+# Eigen is installed. If there is none at all, fetch one -- Eigen is header
+# only, so populate the sources and declare the imported target here rather than
+# running Eigen's own CMake, which would graft its test suite onto this build.
+# Set MDANCE_FETCH_EIGEN=OFF to require an installed Eigen instead.
+find_package(Eigen3 3.4 QUIET)
+if(NOT Eigen3_FOUND)
+    find_package(Eigen3 QUIET)
+endif()
+option(MDANCE_FETCH_EIGEN "Download Eigen when none is installed" ON)
+if(NOT Eigen3_FOUND)
+    if(NOT MDANCE_FETCH_EIGEN)
+        message(FATAL_ERROR
+            "Eigen was not found and MDANCE_FETCH_EIGEN=OFF. Install Eigen "
+            "(apt install libeigen3-dev / brew install eigen) or set "
+            "MDANCE_FETCH_EIGEN=ON to download it.")
+    endif()
+    message(STATUS "Eigen not found; fetching Eigen 3.4.0")
+    include(FetchContent)
+    FetchContent_Declare(eigen
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG 3.4.0
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+        # Pointing SOURCE_SUBDIR at a header directory with no CMakeLists.txt
+        # makes FetchContent populate the sources and skip add_subdirectory,
+        # which would otherwise add 72 targets and 957 ctest entries here.
+        SOURCE_SUBDIR Eigen)
+    FetchContent_MakeAvailable(eigen)
+    if(NOT TARGET Eigen3::Eigen)
+        add_library(Eigen3::Eigen INTERFACE IMPORTED)
+        target_include_directories(Eigen3::Eigen INTERFACE "${eigen_SOURCE_DIR}")
+    endif()
+endif()
 
 # Create library for tools
 add_library(mdance_tools STATIC

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -186,6 +186,12 @@ void KmeansNANI::init_Mu() {
     if (centers.rows() > kClusters){
         centers = centers(Eigen::seq(0, kClusters-1), Eigen::placeholders::all).eval();
     }
+    // The percentage-based initializations can select fewer than kClusters
+    // candidates; catching it here beats silently clustering with fewer
+    // centers than requested (labels would never reach kClusters-1).
+    if (centers.rows() < kClusters){
+        throw std::runtime_error("Initialization produced fewer centers than kClusters; increase percentage or reduce kClusters.");
+    }
 }
 
 // ======================================================= Update Assignments Z
@@ -254,6 +260,9 @@ void KmeansNANI::run_lloyd(int Niter )  {
 
 
 KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(0), percentage(percentage) {
+    if (kClusters < 1 || kClusters > this->data.rows()) {
+        throw std::invalid_argument("kClusters must be between 1 and the number of data points.");
+    }
     centers = Mat::Zero(kClusters, data.cols());
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
@@ -263,6 +272,12 @@ KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitTyp
     run_lloyd(300);
 }
 KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(MD::KinitType::StratAll), seed(0), percentage(percentage), centers(centers) {
+    if (kClusters < 1 || kClusters > this->data.rows()) {
+        throw std::invalid_argument("kClusters must be between 1 and the number of data points.");
+    }
+    if (this->centers.rows() != kClusters || this->centers.cols() != this->data.cols()) {
+        throw std::invalid_argument("centers must have shape (kClusters, nFeatures).");
+    }
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
     set_vectorization_threshold(vectThreshold);

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -42,10 +42,7 @@ void KmeansNANI::set_vectorization_threshold(int threshold){
     if (threshold < 1){
         throw std::invalid_argument("Threshold must be at least 1");
     }
-    if (threshold == std::numeric_limits<int>::infinity()) {
-        throw std::invalid_argument("Threshold must be finite");
-    }
-    threshold = threshold;
+    vectorizationThreshold = threshold;
 }
 
 /*

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -249,7 +249,7 @@ void KmeansNANI::run_lloyd(int Niter )  {
 }
 
 
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(seed), percentage(percentage) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(0), percentage(percentage) {
     centers = Mat::Zero(kClusters, data.cols());
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
@@ -258,7 +258,7 @@ KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitTyp
     init_Mu();
     run_lloyd(300);
 }
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(seed), percentage(percentage), centers(centers) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(MD::KinitType::StratAll), seed(0), percentage(percentage), centers(centers) {
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
     set_vectorization_threshold(vectThreshold);

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -232,7 +232,10 @@ void KmeansNANI::calcMu() {
 
 // ======================================================= Overall Lloyd Alg.
 void KmeansNANI::run_lloyd(int Niter )  {
-    double prevDist,totalDist = 0;
+    // prevDist must start at a value assignClosest() can never return so the
+    // convergence check cannot fire on the first iteration.
+    double prevDist = std::numeric_limits<double>::infinity();
+    double totalDist = 0;
 
     // TODO: store the labels at each frame
     for (int iter=0; iter<Niter; iter++) {

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -143,9 +143,9 @@ void KmeansNANI::reduced_init_Mu(bool isComp) {
     for (int i=nTotal - nMax; i<nTotal; ++i){
         topIndices.push_back(compSimArray[i].second);
     }
-    Mat topCCdata = data(topIndices, Eigen::placeholders::all);
+    Mat topCCdata = data(topIndices, Eigen::all);
     vector<Index> idx = diversitySelection(topCCdata, 100, mt, nAtoms, isComp);
-    centers = topCCdata(idx,Eigen::placeholders::all);
+    centers = topCCdata(idx,Eigen::all);
 }
 
 void KmeansNANI::init_Mu() {
@@ -174,17 +174,17 @@ void KmeansNANI::init_Mu() {
 
     case MD::KinitType::StratAll:
         idx = diversitySelection(data, percentage, mt, nAtoms);
-        centers = data(idx,Eigen::placeholders::all);
+        centers = data(idx,Eigen::all);
         break;
 
     case MD::KinitType::DivSelect:
         idx = diversitySelection(data, percentage, mt, nAtoms, true);
-        centers = data(idx,Eigen::placeholders::all);
+        centers = data(idx,Eigen::all);
         break;
     }
     // only take first kClusters centers
     if (centers.rows() > kClusters){
-        centers = centers(Eigen::seq(0, kClusters-1), Eigen::placeholders::all).eval();
+        centers = centers(Eigen::seq(0, kClusters-1), Eigen::all).eval();
     }
     // The percentage-based initializations can select fewer than kClusters
     // candidates; catching it here beats silently clustering with fewer

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -156,6 +156,10 @@ void KmeansNANI::init_Mu() {
         sampleRowsRandom();
         break;
     
+    // The greedy k-means++ variant is not implemented yet; fall back to the
+    // vanilla k-means++ sampling rather than silently leaving the centers at
+    // their zero-initialized values.
+    case MD::KinitType::KmeansPP:
     case MD::KinitType::VanillaKmeansPP:
         sampleRowsPlusPlus();
         break;

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -196,19 +196,18 @@ void KmeansNANI::init_Mu() {
 
 // ======================================================= Update Assignments Z
 void KmeansNANI::pairwise_distance( Mat &X, Mat &Mu, Mat &Dist ) {
-    int N = data.rows();
-    int D = data.cols();
-    int K = centers.rows();
+    int D = X.cols();
+    int K = Mu.rows();
 
     // For small dims D, for loop is noticeably faster than fully vectorized.
-    // Odd but true.  So we do fastest thing 
+    // Odd but true.  So we do fastest thing
     if ( D <= vectorizationThreshold ) {
         for (int kk=0; kk<K; kk++) {
-            Dist.col(kk) = (data.rowwise() - centers.row(kk)).square().rowwise().sum();
-        }    
+            Dist.col(kk) = (X.rowwise() - Mu.row(kk)).square().rowwise().sum();
+        }
     } else {
-        Dist = -2*(data.matrix() * centers.transpose().matrix());
-        Dist.rowwise() += centers.square().rowwise().sum().transpose().row(0);
+        Dist = -2*(X.matrix() * Mu.transpose().matrix());
+        Dist.rowwise() += Mu.square().rowwise().sum().transpose().row(0);
     }
 }
 
@@ -259,7 +258,7 @@ void KmeansNANI::run_lloyd(int Niter )  {
 }
 
 
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(0), percentage(percentage) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kinit(kinit), seed(0), kClusters(kClusters), mt(mt), nAtoms(nAtoms), percentage(percentage) {
     if (kClusters < 1 || kClusters > this->data.rows()) {
         throw std::invalid_argument("kClusters must be between 1 and the number of data points.");
     }
@@ -271,7 +270,7 @@ KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitTyp
     init_Mu();
     run_lloyd(300);
 }
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(MD::KinitType::StratAll), seed(0), percentage(percentage), centers(centers) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), centers(centers), kinit(MD::KinitType::StratAll), seed(0), kClusters(kClusters), mt(mt), nAtoms(nAtoms), percentage(percentage) {
     if (kClusters < 1 || kClusters > this->data.rows()) {
         throw std::invalid_argument("kClusters must be between 1 and the number of data points.");
     }

--- a/src/cluster/helm.cpp
+++ b/src/cluster/helm.cpp
@@ -114,10 +114,18 @@ vector<HCTree> Helm::genNewClusters(int ZIdx){
     Index minRow, minCol;       //minRow and minCol refer to two different clusters
     
     float mergeDist = clusterDists.minCoeff(&minRow, &minCol);
-    // add check for minRow and minCol being same. This can cause UB or crash. 
+    // add check for minRow and minCol being same. This can cause UB or crash.
     if (minRow == minCol){
         throw std::runtime_error("Got same cluster idx for the two most similar clusters.");
     }
+
+    // eps termination: if the best merge is not similar enough, discard it
+    // before it is recorded anywhere. Bailing out down here used to leave a
+    // phantom row for the rejected merge in the Z matrix.
+    if (eps != -1 && !(mergeDist < eps)) {
+        return vector<HCTree>();
+    }
+
     //Merge the two most similar clusters
     Vec cSum, sqSum;
     cSum = previousClusters[minRow].getRootCSum() + previousClusters[minCol].getRootCSum();
@@ -159,10 +167,7 @@ vector<HCTree> Helm::genNewClusters(int ZIdx){
     Mat clusterDists_temp2 = clusterDists_temp1(clustersToKeep, Eigen::placeholders::all);
     clusterDists = clusterDists_temp2;
 
-    if(eps==-1 || mergeDist < eps){
-        return newClusters;
-    }
-    return vector<HCTree>();
+    return newClusters;
 }
 
 void Helm::updateZMatrix(int idxA, int idxB, int mergedClusts){

--- a/src/cluster/helm.cpp
+++ b/src/cluster/helm.cpp
@@ -163,8 +163,8 @@ vector<HCTree> Helm::genNewClusters(int ZIdx){
         }
         
     }
-    Mat clusterDists_temp1 = clusterDists(Eigen::placeholders::all, clustersToKeep);
-    Mat clusterDists_temp2 = clusterDists_temp1(clustersToKeep, Eigen::placeholders::all);
+    Mat clusterDists_temp1 = clusterDists(Eigen::all, clustersToKeep);
+    Mat clusterDists_temp2 = clusterDists_temp1(clustersToKeep, Eigen::all);
     clusterDists = clusterDists_temp2;
 
     return newClusters;

--- a/src/cluster/helm.cpp
+++ b/src/cluster/helm.cpp
@@ -23,8 +23,7 @@ vector<HCTree> Helm::trimClusters(){
         new cluster tree after trimming (vector<HCTree>)
     */
     vector<pair<double, int>> clusterMsds;
-    int i=0;
-    for(int i=0; i<clusterTree.size(); i++){
+    for(size_t i=0; i<clusterTree.size(); i++){
         Vec cSum = clusterTree.at(i).getRootCSum();
         Vec sqSum = clusterTree.at(i).getRootSQSum();
         int Nik = clusterTree.at(i).getRootNObjects();
@@ -43,20 +42,21 @@ vector<HCTree> Helm::trimClusters(){
     vector<HCTree> newClusterTree;
     if(trimK){
         this->trimIncoming = clusterMsds.size()-trimK;
-        if (trimK >= clusterMsds.size()-1){
+        // compare in double so an empty clusterMsds does not wrap around
+        if (trimK >= (double)clusterMsds.size()-1){
             throw std::runtime_error("trimK is too large!");
         }
-        else if(trimK >= clusterMsds.size()/2){
+        else if(trimK >= clusterMsds.size()/2.0){
             std::cerr<<"trimK is more than 50% of the clusters. This may lead to poor clustering"<<std::endl;
         }
-        for(int i=0; i<clusterMsds.size()-trimK; i++){
+        for(int i=0; i<(double)clusterMsds.size()-trimK; i++){
             int index = clusterMsds[i].second;
-            if (index < 0 || index >= clusterTree.size()) {
+            if (index < 0 || index >= (int)clusterTree.size()) {
                 throw std::runtime_error("Index out of bounds when trimming clusters.");
             }
             newClusterTree.emplace_back(clusterTree[index]);
         }
-    } 
+    }
     else if(trimVal){
         this->trimIncoming = 0;
         for(auto i:clusterMsds){
@@ -126,17 +126,11 @@ vector<HCTree> Helm::genNewClusters(int ZIdx){
         return vector<HCTree>();
     }
 
-    //Merge the two most similar clusters
-    Vec cSum, sqSum;
-    cSum = previousClusters[minRow].getRootCSum() + previousClusters[minCol].getRootCSum();
-    sqSum = previousClusters[minRow].getRootSQSum() + previousClusters[minCol].getRootSQSum();
-
-    int Nik = previousClusters[minRow].getRootNObjects() + previousClusters[minCol].getRootNObjects();
-
-    //Save the new clusters after mergin
+    //Save the new clusters after merging (mergeTree computes the combined
+    //cSum/sqSum/nObjects itself)
     vector<HCTree> newClusters;
     newClusters.reserve(previousClusters.size()+1);
-    for(int i=0; i<previousClusters.size(); i++){
+    for(Index i=0; i<(Index)previousClusters.size(); i++){
         if(i==minRow || i==minCol){;}
         else{
             newClusters.emplace_back(previousClusters[i]);
@@ -225,7 +219,7 @@ float Helm::calcHelmSim(HCTree& firstTree, HCTree& secondTree){
     double sim = extendedComparison(data, n, nAtoms, true, mt);
 
     //Different merging schemes for determining which clusters to merge
-    float helmSim;
+    float helmSim = 0;
     if (mergeScheme == MD::MergeScheme::Intra){
         helmSim = sim;
     }
@@ -253,8 +247,8 @@ void Helm::genClusterDists(vector<HCTree>& previousClusters){
     */
 
     clusterDists = Mat::Zero(previousClusters.size(), previousClusters.size()) + INFINITY;
-    for(int i=0; i<previousClusters.size(); i++){
-        for(int j=i+1; j<previousClusters.size(); j++){
+    for(size_t i=0; i<previousClusters.size(); i++){
+        for(size_t j=i+1; j<previousClusters.size(); j++){
             float helmSim = calcHelmSim(previousClusters[i], previousClusters[j]);
             clusterDists(i, j) = helmSim;
         }

--- a/src/cluster/helm.h
+++ b/src/cluster/helm.h
@@ -1,5 +1,4 @@
 #include "../tools/types.h"
-#include "../tools/cluster.h"
 #include "../tools/hc_utils.h"
 
 class Helm{
@@ -27,7 +26,6 @@ class Helm{
         MD::Metric mt;
         MD::MergeScheme mergeScheme;
         Mat clusterDists;
-        Mat linkMatrix;
         int totalIncoming;
         bool savePairwiseSum;
         string inputTop;
@@ -41,6 +39,4 @@ class Helm{
         float calcHelmSim(HCTree& firstTree, HCTree& secondTree);
         void genClusterDists(vector<HCTree>& previousClusters);
         void updateZMatrix(int idxA, int idxB, int mergedClusts);
-        Mat initialPairwiseMatrix(vector<Cluster>& previousClusters);
-        map<int, vector<Cluster>> linkMatrixToClusterMap();
 };

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -339,7 +339,7 @@ vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metri
 
     set<Index> selectFromN;
     set<Index> selectedSet;
-    for (int i=0; i<indices.size(); ++i) {
+    for (size_t i=0; i<indices.size(); ++i) {
         selectedSet.insert(indices[i]);
     }
     for (int i=0; i<nTotal; ++i) {
@@ -533,6 +533,8 @@ ArrayXXd alignTraj(const ArrayXXd& data, int nAtoms, MD::AlignMethod alignMeth){
         .. _"Size-and-Shape Space Gaussian Mixture Models for Structural Clustering of Molecular Dynamics Trajectories":
         https://pubs.acs.org/doi/abs/10.1021/acs.jctc.1c01290
     */
+
+    (void)nAtoms;  // stub: unused until the alignment methods are implemented
 
     if(alignMeth == MD::AlignMethod::None){
         return data;

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -262,7 +262,7 @@ ArrayXXd trimOutliers(const ArrayXXd& data, int nTrimmed, int nAtoms, bool isMed
             indices.push_back(i);
         }
     }
-    return data(indices, Eigen::placeholders::all);
+    return data(indices, Eigen::all);
 }
 ArrayXXd trimOutliers(const ArrayXXd& data, float nTrimmed, int nAtoms, bool isMedoid, MD::Metric mt) {
     int num = std::floor(data.rows() * nTrimmed);
@@ -327,7 +327,7 @@ vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metri
 
 }
 vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metric mt, int nAtoms, vector<Index>& indices){
-    ArrayXXd selection = data(indices, Eigen::placeholders::all);
+    ArrayXXd selection = data(indices, Eigen::all);
     ArrayXXd selected (mt == MD::Metric::MSD ? 2 : 1, data.row(0).cols());
     selected.row(0) = selection.colwise().sum();
     if (mt == MD::Metric::MSD) {

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -299,7 +299,7 @@ vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metri
         switch(start) {
             case MD::StartSeed::Medoid: seed.push_back(calculateMedoid(data, nAtoms, mt)); break;
             case MD::StartSeed::Outlier: seed.push_back(calculateOutlier(data, nAtoms, mt)); break;
-            case MD::StartSeed::Random: seed.emplace_back(rand() % data.row(0).size()); break;
+            case MD::StartSeed::Random: seed.emplace_back(rand() % data.rows()); break;
         }
         return diversitySelection(data, percentage, mt, nAtoms, seed);
     }

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -198,72 +198,67 @@ Index calculateOutlier(const ArrayXd& data) {
 */
 ArrayXXd trimOutliers(const ArrayXXd& data, int nTrimmed, int nAtoms, bool isMedoid, MD::Metric mt) {
     Index N = data.rows();
+    if (nTrimmed <= 0) {
+        return data;
+    }
+    if (nTrimmed >= N) {
+        return ArrayXXd(0, data.cols());
+    }
+
+    Index medoidIdx = -1;
     ArrayXd cSum;
     ArrayXd sqSumTotal;
-    Index idx;
     if (isMedoid) {
-        idx = calculateMedoid(data, nAtoms, mt);
-        cSum = data.row(idx);
+        medoidIdx = calculateMedoid(data, nAtoms, mt);
     } else {
         cSum = data.colwise().sum();
         sqSumTotal = data.square().colwise().sum();
     }
 
-
-    // We will find our outliers by performing a heapSort using a maxHeap of size nTrimmed
-    vector<pair<double, int>> compSims;
-    compSims.reserve(nTrimmed);
-    ArrayXXd compData (2,data.row(0).size());
-
-    for (Index i=0; i<nTrimmed; ++i) {
+    ArrayXXd compData(2, data.cols());
+    auto trimValue = [&](Index i) {
         if (isMedoid) {
-            if (i != idx){
-                compData.row(0) = data.row(i);
-                compData.row(1) = cSum;
-                compSims.emplace_back(pair<double,int>(extendedComparison(compData, N-1, nAtoms, false, mt), i));
-            } else{
-                continue;
-            }
-        } else {
-            compData.row(0) = cSum.transpose() - data.row(i);
-            compData.row(1) = sqSumTotal.transpose() - data.row(i).square();
+            // Dissimilarity between frame i and the medoid (a 2-object
+            // comparison; the medoid itself scores 0 and is never trimmed).
+            compData.row(0) = data.row(i);
+            compData.row(1) = data.row(medoidIdx);
+            return extendedComparison(compData, 2, nAtoms, false, mt);
+        }
+        // Complementary similarity: dissimilarity of the data without frame i.
+        compData.row(0) = cSum.transpose() - data.row(i);
+        compData.row(1) = sqSumTotal.transpose() - data.row(i).square();
+        return extendedComparison(compData, N - 1, nAtoms, true, mt);
+    };
 
-            compSims.emplace_back(pair<double,int>(extendedComparison(compData, N-1, nAtoms, true, mt), i));
+    // Select the nTrimmed outliers in O(N log nTrimmed) with a bounded heap.
+    // comp_sim trims the LOWEST complementary similarities (a max-heap keeps
+    // the nTrimmed smallest values); sim_to_medoid trims the HIGHEST
+    // distances to the medoid (a min-heap keeps the nTrimmed largest).
+    vector<pair<double, Index>> heap;
+    heap.reserve(nTrimmed);
+    auto cmp = [isMedoid](const pair<double, Index>& a, const pair<double, Index>& b) {
+        return isMedoid ? a.first > b.first : a.first < b.first;
+    };
+    for (Index i = 0; i < N; ++i) {
+        double val = trimValue(i);
+        if ((Index)heap.size() < nTrimmed) {
+            heap.emplace_back(val, i);
+            std::push_heap(heap.begin(), heap.end(), cmp);
+        } else if (isMedoid ? (val > heap.front().first) : (val < heap.front().first)) {
+            std::pop_heap(heap.begin(), heap.end(), cmp);
+            heap.back() = pair<double, Index>(val, i);
+            std::push_heap(heap.begin(), heap.end(), cmp);
         }
     }
-    std::make_heap(compSims.begin(),compSims.end());
-    for (Index i=nTrimmed; i<N; ++i) {
-        double simVal;
-        if (isMedoid) {
-            if (i != idx){
-                compData.row(0) = data.row(i);
-                compData.row(1) = cSum;
-                simVal = extendedComparison(compData, N-1, nAtoms, false, mt);
-            } else {
-                continue;
-            }
-        } else {
-            compData.row(0) = cSum.transpose() - data.row(i);
-            compData.row(1) = sqSumTotal.transpose() - data.row(i).square();
 
-            simVal = extendedComparison(compData, N-1, nAtoms, true, mt);
-        }
-
-        if (simVal < compSims[0].first) {
-            std::pop_heap(compSims.begin(), compSims.end());
-            compSims.pop_back();
-            compSims.emplace_back(pair<double,int>(simVal,i));
-            std::push_heap(compSims.begin(), compSims.end());
-        }
-    }
-    vector<bool> isInHeap(N, false);
-    for (Index i=0; i<nTrimmed; ++i){
-        isInHeap[compSims[i].second] = true;
+    vector<bool> trimmed(N, false);
+    for (auto& p : heap) {
+        trimmed[p.second] = true;
     }
     vector<Index> indices;
     indices.reserve(N - nTrimmed);
-    for (Index i=0; i<N; ++i) {
-        if(!isInHeap[i]){
+    for (Index i = 0; i < N; ++i) {
+        if (!trimmed[i]) {
             indices.push_back(i);
         }
     }

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -306,7 +306,7 @@ vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metri
     Index N = data.rows();
     int nMax = N * percentage / 100;
     if (nMax > N) {
-        std::runtime_error("Percentage is too high for the given matrix size");
+        throw std::runtime_error("Percentage is too high for the given matrix size");
     }
     vector<Index> indices (nMax);
     if (nMax == 1)
@@ -354,7 +354,7 @@ vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metri
     }
 
     indices.reserve(nMax);
-    while (indices.size() < nMax) {
+    while ((int)indices.size() < nMax && !selectFromN.empty()) {
         Index newIndexN = getNewIndexN(data, mt, selected, indices.size(), selectFromN, nAtoms);
 
         selected.row(0) += data.row(newIndexN);

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -426,48 +426,66 @@ Index getNewIndexN(const ArrayXXd& data, MD::Metric mt, ArrayXXd& selectedConden
  * Reference: https://github.com/mqcomplab/MDANCE/blob/016bd9aff30d1c2add26b36bfcf64aa665a34a1d/src/mdance/tools/bts.py#L652
 */
 ArrayXi repSample(const ArrayXXd& data, MD::Metric mt, int nAtoms, int nBins, double nSamples, bool hardCap) {
+    // nSamples in (0,1) is a fraction of the data; anything >= 1 is a count.
     if (nSamples < 1) {
-        return repSample(data, mt, nAtoms, nBins, std::round(nSamples * data.rows()), hardCap);
+        return repSample(data, mt, nAtoms, nBins, (int)(data.rows() * nSamples), hardCap);
     }
-    std::cerr << "Cannot sample more than 100\% of the data" << std::endl;
-    return ArrayXi();
+    return repSample(data, mt, nAtoms, nBins, (int)nSamples, hardCap);
 }
 ArrayXi repSample(const ArrayXXd& data, MD::Metric mt, int nAtoms, int nBins, int nSamples, bool hardCap) {
+    Index N = data.rows();
+    if (nSamples <= 0 || N == 0) {
+        return ArrayXi();
+    }
+    if (nBins < 1) {
+        throw std::invalid_argument("nBins must be at least 1");
+    }
+
     ArrayXd compSims = calculateCompSim(data, nAtoms, mt);
+    // (compSim value, original index), sorted by value
     vector<pair<double,int>> compSimArray;
-    compSimArray.reserve(compSims.size());
-    for (int i=0; i<compSims.size(); ++i){
-        compSimArray.emplace_back(compSims[i],i);
+    compSimArray.reserve(N);
+    for (int i=0; i<N; ++i){
+        compSimArray.emplace_back(compSims[i], i);
     }
     std::sort(compSimArray.begin(), compSimArray.end());
-    double mi = compSimArray[0].first;
-    double ma = compSimArray[compSims.size()-1].first;
 
+    double mi = compSimArray.front().first;
+    double ma = compSimArray.back().first;
+    double binWidth = (ma - mi) / nBins;
 
-    int step = std::floor((ma - mi) / nBins);
+    // Distribute the objects across nBins bins of equal compSim width. When
+    // every value is identical the reference puts everything in the last bin.
     vector<vector<int>> bins(nBins);
-    int idx=0;
-    for (int i=0; i<compSims.size(); ++i) {
-        if (compSimArray[i].first - mi >= (idx+1)*step) {
-            ++idx;
-        }
-        bins[idx].push_back(compSimArray[i].second);
+    for (auto& p : compSimArray) {
+        int b = binWidth > 0 ? (int)((p.first - mi) / binWidth) : nBins - 1;
+        if (b < 0) b = 0;
+        if (b >= nBins) b = nBins - 1;  // the maximum value lands in the last bin
+        bins[b].push_back(p.second);
     }
-    VectorXi sampledMols(nSamples);
-    int i=0;
-    int cnt=0;
-    while (sampledMols.size() < nSamples) {
-        for (int b=0; b<bins.size(); ++b) {
-            if (bins[b].size() > i) {
-                sampledMols[cnt] = bins[b][i];
-                ++cnt;
-                if (hardCap && cnt >= nSamples)
+
+    // Round-robin over the bins, taking the next unused object of each bin per
+    // pass. With hardCap the collection stops exactly at nSamples; otherwise
+    // the current pass is completed first (so slightly more than nSamples may
+    // be returned), as in the Python reference.
+    vector<int> sampled;
+    sampled.reserve(nSamples);
+    for (int depth = 0; (int)sampled.size() < nSamples; ++depth) {
+        bool added = false;
+        for (int b = 0; b < nBins; ++b) {
+            if ((int)bins[b].size() > depth) {
+                sampled.push_back(bins[b][depth]);
+                added = true;
+                if (hardCap && (int)sampled.size() >= nSamples)
                     break;
             }
         }
-        ++i;
+        if (!added) {
+            break;  // every bin is exhausted: fewer than nSamples objects exist
+        }
     }
-    return sampledMols;
+
+    return Eigen::Map<ArrayXi>(sampled.data(), sampled.size());
 }
 
 /* Refine a distance matrix by setting the diagonal to zero and symmetrizing the matrix

--- a/src/tools/bts.h
+++ b/src/tools/bts.h
@@ -18,6 +18,7 @@ ArrayXXd trimOutliers(const ArrayXXd& data, float nTrimmed, int nAtoms = 1, bool
 vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metric mt = MD::Metric::MSD, int nAtoms = 1, bool isCompSim = false, MD::StartSeed start = MD::StartSeed::Medoid);
 vector<Index> diversitySelection(const ArrayXXd& data, int percentage, MD::Metric mt, int nAtoms, vector<Index>& start);
 Index getNewIndexN(const ArrayXXd& data, MD::Metric mt, ArrayXXd& selectedCondensed, int N, set<Index>& selectFromN, int nAtoms);
-ArrayXi repSample(const ArrayXXd& data, MD::Metric mt = MD::Metric::MSD, int nAtoms = 1, int nBins = 10, int nSamples = 100, bool hardCap = false);
+ArrayXi repSample(const ArrayXXd& data, MD::Metric mt = MD::Metric::MSD, int nAtoms = 1, int nBins = 10, int nSamples = 100, bool hardCap = true);
+ArrayXi repSample(const ArrayXXd& data, MD::Metric mt, int nAtoms, int nBins, double nSamples, bool hardCap = true);
 ArrayXXd refineDisMatrix(const ArrayXXd& data);
 ArrayXXd alignTraj(const ArrayXXd& data, int nAtoms, MD::AlignMethod = MD::AlignMethod::None);

--- a/src/tools/cluster.cpp
+++ b/src/tools/cluster.cpp
@@ -1,10 +1,6 @@
 #include "cluster.h"
 
-Cluster::Cluster(){
-    this->indices;
-    this->cSum;
-    this->sqSum;
-    this->n;
+Cluster::Cluster() : n(0) {
 }
 Cluster::Cluster(Veci indices, Vec cSum, Vec sqSum, int n){
     this->indices = indices;

--- a/src/tools/esim.h
+++ b/src/tools/esim.h
@@ -5,4 +5,6 @@
 #include "types.h"
 
 MD::Indices genSimIdx(const ArrayXd& cTotal, int nObjects, MD::Threshold& cThreshold, int wt);
-MD::Counters calculateCounters(const ArrayXd& cTotal, int nObjects, MD::Threshold& cThreshold, int wFactor = INT_MIN);
+// wFactor = 0 selects the "fraction" weight function (the reference default);
+// any other value n selects the power_n weights.
+MD::Counters calculateCounters(const ArrayXd& cTotal, int nObjects, MD::Threshold& cThreshold, int wFactor = 0);

--- a/src/tools/hc_utils.cpp
+++ b/src/tools/hc_utils.cpp
@@ -13,8 +13,8 @@ HCTreeNode::HCTreeNode(std::list<int> clusterIdx, Vec cSumIn, Vec sqsum, int nOb
     setSQSum(sqsum);
     setClusterIndices(clusterIdx);
     setNObjects(nObjects);
-    setLeftPtr(NULL);
-    setRightPtr(NULL);
+    setLeftPtr(nullptr);
+    setRightPtr(nullptr);
     setZIdx(z_ind);
 };
 
@@ -59,7 +59,7 @@ void HCTreeNode::setZIdx(int z_ind){
  * @brief Get the left pointer for this node.
  * @return HCTreeNode* A pointer to the left child node.
  */
-HCTreeNode* HCTreeNode::getLeftPtr(){
+std::shared_ptr<HCTreeNode> HCTreeNode::getLeftPtr(){
     return leftPtr;
 }
 
@@ -67,15 +67,15 @@ HCTreeNode* HCTreeNode::getLeftPtr(){
  * @brief Set the left pointer for this node.
  * @param input_left A pointer to the left child node.
  */
-void HCTreeNode::setLeftPtr(HCTreeNode* input_left){
+void HCTreeNode::setLeftPtr(std::shared_ptr<HCTreeNode> input_left){
     leftPtr = input_left;
 }
 
 /**
  * @brief Get the right pointer for this node.
- * @return HCTreeNode* A pointer to the right child node.
+ * @return std::shared_ptr<HCTreeNode> A pointer to the right child node.
  */
-HCTreeNode* HCTreeNode::getRightPtr(){
+std::shared_ptr<HCTreeNode> HCTreeNode::getRightPtr(){
     return rightPtr;
 }
 
@@ -83,7 +83,7 @@ HCTreeNode* HCTreeNode::getRightPtr(){
  * @brief Set the right pointer for this node.
  * @param input_right A pointer to the right child node.
  */
-void HCTreeNode::setRightPtr(HCTreeNode* input_right){
+void HCTreeNode::setRightPtr(std::shared_ptr<HCTreeNode> input_right){
     rightPtr = input_right;
 }
 
@@ -129,25 +129,25 @@ void HCTreeNode::setClusterIndices(std::list<int> idx){
  * of the tree, which is an instance of the HCTreeNode class.
  * 
  */
-HCTree::HCTree(){ 
-    rootPtr = NULL;
+HCTree::HCTree(){
+    rootPtr = nullptr;
 }
 
 /**
  * @brief Get the root node of the hierarchical clustering tree.
- * 
- * @return HCTreeNode* A pointer to the root node of the tree.
+ *
+ * @return std::shared_ptr<HCTreeNode> A pointer to the root node of the tree.
  */
-HCTreeNode* HCTree::getRoot(){
+std::shared_ptr<HCTreeNode> HCTree::getRoot(){
     return rootPtr;
 }
 
 /**
  * @brief Set the root node of the hierarchical clustering tree.
- * 
+ *
  * @param input_root A pointer to the new root node of the tree.
  */
-void HCTree::setRoot(HCTreeNode* input_root){
+void HCTree::setRoot(std::shared_ptr<HCTreeNode> input_root){
     rootPtr = input_root;
 }
 
@@ -201,7 +201,7 @@ int HCTree::getRootZIdx(){ //z_index
  * @param z_ind An integer representing the z_index for the new root node.
  */
 void HCTree::insertRoot(std::list<int> idx, Vec cSum, Vec sqsum, int nObjects, int z_ind){
-    rootPtr = new HCTreeNode(idx, cSum, sqsum, nObjects, z_ind);
+    rootPtr = std::make_shared<HCTreeNode>(idx, cSum, sqsum, nObjects, z_ind);
 }
 
 /**
@@ -226,7 +226,7 @@ void HCTree::mergeTree(HCTree other_tree, int new_z_ind){
     idx.sort();
     int nObjectsNew = other_tree.getRootNObjects() + getRootNObjects();
     //create new root node
-    HCTreeNode* new_root = new HCTreeNode(idx, csum_new, sqsum_new, nObjectsNew, new_z_ind);
+    std::shared_ptr<HCTreeNode> new_root = std::make_shared<HCTreeNode>(idx, csum_new, sqsum_new, nObjectsNew, new_z_ind);
 
     // set left and right pointers so that z_left < z_right
     int z_other_tree = other_tree.getRootZIdx();

--- a/src/tools/hc_utils.h
+++ b/src/tools/hc_utils.h
@@ -3,6 +3,7 @@
 
 #include <Eigen/Dense>
 #include <list>
+#include <memory>
 
 #include "types.h"
 
@@ -13,7 +14,10 @@ class HCTreeNode{
     //     sqSum: columnwise sum of squares of the data for the molecules in the
     //     clusterIndices: indices of the initial clusters in the cluster
     //     n_objects: number of molecules in the cluster
-    // in addition to pointers to the left and right child nodes. 
+    // in addition to pointers to the left and right child nodes.
+    //
+    // Nodes are shared between trees (a merged tree points at the roots of the
+    // two trees it was built from), so they are held by std::shared_ptr.
 
     friend class HCTree;
 
@@ -23,9 +27,9 @@ class HCTreeNode{
         Vec cSum; // columnwise sum of data
         Vec sqSum; // columnwise sum of squares of data
         std::list<int> clusterIndices; // list of indices of initial clusters in the cluster
-        HCTreeNode* leftPtr; // pointer to left child node
-        HCTreeNode* rightPtr; // pointer to right child node
-        
+        std::shared_ptr<HCTreeNode> leftPtr; // pointer to left child node
+        std::shared_ptr<HCTreeNode> rightPtr; // pointer to right child node
+
     public:
         HCTreeNode(std::list<int> idx, Vec cSum, Vec sqsum, int nObjects, int z_ind);
 
@@ -37,13 +41,13 @@ class HCTreeNode{
 
         void setSQSum(Vec sqSum);
 
-        HCTreeNode* getLeftPtr();
+        std::shared_ptr<HCTreeNode> getLeftPtr();
 
-        void setLeftPtr(HCTreeNode* input_left);
+        void setLeftPtr(std::shared_ptr<HCTreeNode> input_left);
 
-        HCTreeNode* getRightPtr();
+        std::shared_ptr<HCTreeNode> getRightPtr();
 
-        void setRightPtr(HCTreeNode* input_right);
+        void setRightPtr(std::shared_ptr<HCTreeNode> input_right);
 
         void setNObjects(int n_mol);
 
@@ -60,13 +64,13 @@ class HCTreeNode{
 
 class HCTree{
     private:
-        HCTreeNode* rootPtr;
+        std::shared_ptr<HCTreeNode> rootPtr;
     public:
-        HCTree(); // constructor that sets root ptr to NULL
+        HCTree(); // constructor that sets root ptr to null
 
-        HCTreeNode* getRoot();
+        std::shared_ptr<HCTreeNode> getRoot();
 
-        void setRoot(HCTreeNode* input_root);
+        void setRoot(std::shared_ptr<HCTreeNode> input_root);
 
         Vec getRootCSum();
 

--- a/src/tools/scores.cpp
+++ b/src/tools/scores.cpp
@@ -10,7 +10,7 @@
  * 
  * Reference: This code does not include any of the parameter checking: https://github.com/scikit-learn/scikit-learn/blob/c5497b7f7eacfaff061cf68e09bcd48aa93d4d6b/sklearn/metrics/cluster/_unsupervised.py#L325
 */
-double calinskiHarabaszScore(const ArrayXXd data, VectorXi labels) {
+double calinskiHarabaszScore(const ArrayXXd& data, const VectorXi& labels) {
     std::map<int, vector<int>> clusters;
 
     for (int i=0; i<labels.size(); ++i) {
@@ -53,7 +53,7 @@ double calinskiHarabaszScore(const ArrayXXd data, VectorXi labels) {
  * 
  * Reference: This code does not include any of the parameter checking: https://github.com/scikit-learn/scikit-learn/blob/c5497b7f7eacfaff061cf68e09bcd48aa93d4d6b/sklearn/metrics/cluster/_unsupervised.py#L396
 */
-double daviesBouldinScore(const ArrayXXd data, VectorXi labels) {
+double daviesBouldinScore(const ArrayXXd& data, const VectorXi& labels) {
     std::map<int, vector<int>> clusters;
 
     for (int i=0; i<labels.size(); ++i) {

--- a/src/tools/scores.cpp
+++ b/src/tools/scores.cpp
@@ -27,7 +27,7 @@ double calinskiHarabaszScore(const ArrayXXd data, VectorXi labels) {
     ArrayXd mean = data.colwise().sum() / data.rows();
     
     for (auto k=clusters.begin(); k != clusters.end(); ++k) {
-        ArrayXXd cluster = data(k->second,Eigen::placeholders::all);
+        ArrayXXd cluster = data(k->second,Eigen::all);
         ArrayXd clusterMean = cluster.colwise().sum() / cluster.rows();
 
         extraDisp += cluster.rows() * (clusterMean - mean).square().sum();
@@ -72,7 +72,7 @@ double daviesBouldinScore(const ArrayXXd data, VectorXi labels) {
     int c=0;
 
     for (auto k=clusters.begin(); k != clusters.end(); ++k) {
-        ArrayXXd cluster = data(k->second,Eigen::placeholders::all);
+        ArrayXXd cluster = data(k->second,Eigen::all);
         centroids.row(c) = cluster.colwise().sum() / cluster.rows();
         intraDists[c] = 0;
         for (int i=0; i<cluster.rows(); ++i) {

--- a/src/tools/scores.cpp
+++ b/src/tools/scores.cpp
@@ -22,6 +22,12 @@ double calinskiHarabaszScore(const ArrayXXd& data, const VectorXi& labels) {
         }
     }
 
+    // With a single cluster there is no between-cluster dispersion and the
+    // ratio below is 0/0. sklearn rejects k < 2 outright; returning 0 keeps the
+    // score a real number for callers that serialize it.
+    if (clusters.size() < 2)
+        return 0;
+
     double extraDisp = 0;
     double intraDisp = 0;
     ArrayXd mean = data.colwise().sum() / data.rows();

--- a/src/tools/scores.h
+++ b/src/tools/scores.h
@@ -1,4 +1,4 @@
 #include "types.h"
 
-double calinskiHarabaszScore(const ArrayXXd data, VectorXi labels);
-double daviesBouldinScore(const ArrayXXd data, VectorXi labels);
+double calinskiHarabaszScore(const ArrayXXd& data, const VectorXi& labels);
+double daviesBouldinScore(const ArrayXXd& data, const VectorXi& labels);

--- a/src/tools/types.h
+++ b/src/tools/types.h
@@ -109,6 +109,7 @@ namespace MD {
             bub(bub), fai(fai), gle(gle), ja(ja), jt(jt), rt(rt), rr(rr), sm(sm), ss1(ss1), ss2(ss2) {}; 
         double getIndex(Metric mt){
             switch(mt) {
+                case Metric::MSD: return 0;  // MSD is not a similarity index
                 case Metric::BUB: return bub;
                 case Metric::Fai: return fai;
                 case Metric::Gle: return gle;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,15 +2,16 @@ cmake_minimum_required(VERSION 3.15)
 
 find_package(GTest REQUIRED)
 
-add_executable(test test_utils.cpp 
+# NOTE: do not name the target "test" -- that name is reserved by CMake once
+# CTest support is enabled, and it also shadows the conventional `make test`.
+add_executable(mdance_gtests test_utils.cpp
                     test_main.cpp
                     test_kmeans.cpp
                     test_helm.cpp
 )
-target_link_libraries(test PRIVATE 
+target_link_libraries(mdance_gtests PRIVATE
                     GTest::GTest
                     GTest::Main
                     mdance)
-                    
-enable_testing()
-add_test(NAME mdance_tests COMMAND test)
+
+add_test(NAME mdance_tests COMMAND mdance_gtests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(mdance_gtests test_utils.cpp
                     test_main.cpp
                     test_kmeans.cpp
                     test_helm.cpp
+                    test_bts.cpp
 )
 target_link_libraries(mdance_gtests PRIVATE
                     GTest::GTest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(mdance_gtests test_utils.cpp
                     test_kmeans.cpp
                     test_helm.cpp
                     test_bts.cpp
+                    test_tools.cpp
 )
 target_link_libraries(mdance_gtests PRIVATE
                     ${MDANCE_GTEST_LIBS}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,39 @@
 cmake_minimum_required(VERSION 3.15)
 
-find_package(GTest REQUIRED)
+# GoogleTest, handled like Eigen in src/CMakeLists.txt: prefer an installed
+# copy, fetch one when there is none, and if neither is possible skip the test
+# target rather than failing the configure -- someone who only wants to build
+# the library should not be required to have a test framework.
+find_package(GTest QUIET)
+option(MDANCE_FETCH_GTEST "Download GoogleTest when none is installed" ON)
+if(NOT GTest_FOUND AND MDANCE_FETCH_GTEST)
+    message(STATUS "GoogleTest not found; fetching v1.15.2")
+    include(FetchContent)
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.15.2
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE)
+    FetchContent_MakeAvailable(googletest)
+endif()
+
+# Target names differ by source: a modern FindGTest and the fetched build both
+# provide GTest::gtest_main, the fetched build also the bare gtest_main, and an
+# older FindGTest only GTest::Main.
+if(TARGET GTest::gtest_main)
+    set(MDANCE_GTEST_LIBS GTest::gtest GTest::gtest_main)
+elseif(TARGET gtest_main)
+    set(MDANCE_GTEST_LIBS gtest gtest_main)
+elseif(TARGET GTest::Main)
+    set(MDANCE_GTEST_LIBS GTest::GTest GTest::Main)
+else()
+    message(STATUS
+        "GoogleTest unavailable (and MDANCE_FETCH_GTEST=OFF); skipping the test "
+        "target. The library still builds.")
+    return()
+endif()
 
 # NOTE: do not name the target "test" -- that name is reserved by CMake once
 # CTest support is enabled, and it also shadows the conventional `make test`.
@@ -11,8 +44,9 @@ add_executable(mdance_gtests test_utils.cpp
                     test_bts.cpp
 )
 target_link_libraries(mdance_gtests PRIVATE
-                    GTest::GTest
-                    GTest::Main
+                    ${MDANCE_GTEST_LIBS}
                     mdance)
+# GoogleTest 1.15 requires C++14; the rest of this project is C++17.
+target_compile_features(mdance_gtests PRIVATE cxx_std_17)
 
 add_test(NAME mdance_tests COMMAND mdance_gtests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,4 +49,11 @@ target_link_libraries(mdance_gtests PRIVATE
 # GoogleTest 1.15 requires C++14; the rest of this project is C++17.
 target_compile_features(mdance_gtests PRIVATE cxx_std_17)
 
-add_test(NAME mdance_tests COMMAND mdance_gtests)
+# The fixtures locate their data as
+#   current_path().parent_path().parent_path() / "tests" / "data"
+# (see the comment in test_kmeans.cpp), which only resolves when the working
+# directory is exactly two levels below the source root -- true for an in-source
+# build/tests/, false for every out-of-source build directory. Running the suite
+# from tests/data makes that expression resolve for any build layout.
+add_test(NAME mdance_tests COMMAND mdance_gtests
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)

--- a/tests/test_bts.cpp
+++ b/tests/test_bts.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include "../src/tools/bts.h"
+#include "../src/cluster/KMeansRex/KMeans.h"
+
+namespace {
+
+// 12 points, 2 features: three loose groups and one far outlier (row 10).
+// The expected values in these tests were computed with a NumPy
+// transcription of the MDANCE Python reference (bts.py @ 016bd9a).
+ArrayXXd makeToyData() {
+    ArrayXXd X(12, 2);
+    X << 1.0, 2.0,
+         2.0, 2.0,
+         2.0, 3.0,
+         1.5, 2.5,
+         8.0, 7.0,
+         8.0, 8.0,
+         7.5, 7.5,
+         8.5, 7.2,
+         4.0, 5.0,
+         4.5, 4.5,
+         25.0, 80.0,
+         5.0, 5.0;
+    return X;
+}
+
+void expectKeptRows(const ArrayXXd& trimmed, const ArrayXXd& X, const std::vector<int>& kept) {
+    ASSERT_EQ(trimmed.rows(), (Index)kept.size());
+    for (size_t i = 0; i < kept.size(); ++i) {
+        EXPECT_TRUE((trimmed.row(i) == X.row(kept[i])).all()) << "kept row " << i;
+    }
+}
+
+}  // namespace
+
+TEST(BtsTools, MedoidAndOutlier) {
+    ArrayXXd X = makeToyData();
+    EXPECT_EQ(calculateMedoid(X), 5);
+    EXPECT_EQ(calculateOutlier(X), 10);
+}
+
+TEST(BtsTools, TrimOutliersCompSim) {
+    ArrayXXd X = makeToyData();
+    // reference trims rows 10 (outlier), 0 and 1: the lowest comp_sim values
+    expectKeptRows(trimOutliers(X, 3, 1, false), X, {2, 3, 4, 5, 6, 7, 8, 9, 11});
+}
+
+TEST(BtsTools, TrimOutliersSimToMedoid) {
+    ArrayXXd X = makeToyData();
+    // the medoid is row 5; the reference trims the three frames FARTHEST from
+    // it (rows 10, 0, 3). The inverted criterion used to trim the closest.
+    expectKeptRows(trimOutliers(X, 3, 1, true), X, {1, 2, 4, 5, 6, 7, 8, 9, 11});
+}
+
+TEST(BtsTools, TrimOutliersFraction) {
+    // docstring example from the Python reference
+    ArrayXXd X(6, 2);
+    X << 1, 2,  2, 2,  2, 3,  8, 7,  8, 8,  25, 80;
+    expectKeptRows(trimOutliers(X, 0.6f, 1, false), X, {2, 3, 4});
+}
+
+TEST(BtsTools, TrimOutliersEdgeCases) {
+    ArrayXXd X = makeToyData();
+    EXPECT_EQ(trimOutliers(X, 0, 1, false).rows(), X.rows());
+    EXPECT_EQ(trimOutliers(X, (int)X.rows(), 1, false).rows(), 0);
+    EXPECT_EQ(trimOutliers(X, 100, 1, true).rows(), 0);
+}
+
+TEST(BtsTools, RepSampleMatchesReference) {
+    ArrayXXd X = makeToyData();
+    std::vector<int> expected = {10, 0, 1, 3, 2};
+    ArrayXi s = repSample(X, MD::Metric::MSD, 1, 3, 5, true);
+    ASSERT_EQ(s.size(), (Index)expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(s[i], expected[i]) << "sample " << i;
+    }
+    // the soft cap gives the same result here (the capping pass adds nothing)
+    ArrayXi soft = repSample(X, MD::Metric::MSD, 1, 3, 5, false);
+    ASSERT_EQ(soft.size(), (Index)expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(soft[i], expected[i]) << "sample " << i;
+    }
+}
+
+TEST(BtsTools, RepSampleFraction) {
+    ArrayXXd X = makeToyData();
+    // 0.5 of 12 rows -> 6 samples
+    std::vector<int> expected = {10, 0, 1, 3, 2, 9};
+    ArrayXi s = repSample(X, MD::Metric::MSD, 1, 3, 0.5, true);
+    ASSERT_EQ(s.size(), (Index)expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(s[i], expected[i]) << "sample " << i;
+    }
+}
+
+TEST(BtsTools, RepSampleMoreThanAvailable) {
+    // must terminate and return every object exactly once (the reference
+    // implementation loops forever here)
+    ArrayXXd X = makeToyData();
+    ArrayXi s = repSample(X, MD::Metric::MSD, 1, 3, 100, true);
+    ASSERT_EQ(s.size(), X.rows());
+    std::vector<bool> seen(X.rows(), false);
+    for (Index i = 0; i < s.size(); ++i) {
+        ASSERT_GE(s[i], 0);
+        ASSERT_LT(s[i], (int)X.rows());
+        EXPECT_FALSE(seen[s[i]]) << "duplicate index " << s[i];
+        seen[s[i]] = true;
+    }
+}
+
+TEST(BtsTools, RepSampleIdenticalObjects) {
+    // zero comp_sim range: everything falls into one bin; must not crash
+    ArrayXXd X = ArrayXXd::Ones(8, 3);
+    ArrayXi s = repSample(X, MD::Metric::MSD, 1, 10, 4, true);
+    ASSERT_EQ(s.size(), 4);
+    for (Index i = 0; i < s.size(); ++i) {
+        ASSERT_GE(s[i], 0);
+        ASSERT_LT(s[i], (int)X.rows());
+    }
+}
+
+TEST(BtsTools, DiversitySelectionRejectsOverPercentage) {
+    ArrayXXd X = makeToyData();
+    EXPECT_THROW(diversitySelection(X, 200), std::runtime_error);
+}
+
+TEST(KMeansNaniInit, KmeansPPProducesRealCenters) {
+    // KinitType::KmeansPP used to fall through init_Mu without initializing
+    // the centers, silently clustering around the zero matrix.
+    ArrayXXd X = makeToyData();
+    KmeansNANI km(X, 3, MD::Metric::MSD, MD::KinitType::KmeansPP, 1, 10);
+    EXPECT_GT(km.getCenters().abs().sum(), 0.0);
+    ArrayXi labels = km.getLabels();
+    ASSERT_EQ(labels.size(), X.rows());
+    for (Index i = 0; i < labels.size(); ++i) {
+        EXPECT_GE(labels[i], 0);
+        EXPECT_LT(labels[i], 3);
+    }
+}
+
+TEST(KMeansNaniInit, RejectsInvalidKClusters) {
+    ArrayXXd X = makeToyData();
+    EXPECT_THROW(KmeansNANI(X, 0, MD::Metric::MSD, MD::KinitType::Random, 1, 10), std::invalid_argument);
+    EXPECT_THROW(KmeansNANI(X, 13, MD::Metric::MSD, MD::KinitType::Random, 1, 10), std::invalid_argument);
+    Mat badCenters = Mat::Zero(2, 2);
+    EXPECT_THROW(KmeansNANI(X, 3, MD::Metric::MSD, badCenters, 1, 10), std::invalid_argument);
+}

--- a/tests/test_helm.cpp
+++ b/tests/test_helm.cpp
@@ -82,7 +82,7 @@ Mat TestHelm::getSelectedData(vector<HCTree> clusters){
             }
         }
     }
-    Mat selectedData = data(selectedFrameIndices, Eigen::placeholders::all);
+    Mat selectedData = data(selectedFrameIndices, Eigen::all);
     return selectedData;
 }
 

--- a/tests/test_helm.cpp
+++ b/tests/test_helm.cpp
@@ -277,6 +277,11 @@ TEST_F(TestHelm, TestEps){
     pair<double, double> scoreRes = helm.computeScores(clusters, selectedData);
     EXPECT_NEAR(scoreRes.first, 302.7012989347063, 1e-5);
     EXPECT_NEAR(scoreRes.second, 1.755325543510106, 1e-5);
+
+    // the Z matrix must contain exactly one row per applied merge; the
+    // rejected merge that terminates an eps run must not be recorded
+    Mat Z = helm.getZMatrix();
+    EXPECT_EQ(Z.rows(), (Index)(clusterTree.size() - clusters.size()));
 }
 
 TEST_F(TestHelm, TestTrimVal){

--- a/tests/test_helm.cpp
+++ b/tests/test_helm.cpp
@@ -4,9 +4,9 @@
 #include "test_helm.h"
 #include "test_utils.h"
 
-#include "../../src/cluster/helm.h"
-#include "../../tools/bts.h"
-#include "../../tools/scores.cpp"
+#include "../src/cluster/helm.h"
+#include "../src/tools/bts.h"
+#include "../src/tools/scores.h"
 
 TestHelm::TestHelm() {
     // read in data:

--- a/tests/test_helm.h
+++ b/tests/test_helm.h
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "../src/tools/types.h"
-#include "../../../src/tools/cluster.h"
-#include "../../tools/hc_utils.h"
+#include "../src/tools/hc_utils.h"
 
 // test fixture for helm
 class TestHelm : public ::testing::Test {

--- a/tests/test_tools.cpp
+++ b/tests/test_tools.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "../src/tools/cluster.h"
+#include "../src/tools/scores.h"
+
+namespace {
+
+ArrayXXd spreadOutPoints() {
+    ArrayXXd data(9, 4);
+    for (int i = 0; i < 9; ++i) {
+        for (int j = 0; j < 4; ++j) data(i, j) = i * 3.0 + j;
+    }
+    return data;
+}
+
+}  // namespace
+
+// A single cluster leaves no between-cluster dispersion, so the
+// Calinski-Harabasz ratio is 0/0. The resulting nan propagates into anything
+// that serializes the score -- and is not representable in JSON at all.
+TEST(Scores, FiniteForASingleCluster) {
+    ArrayXXd data = spreadOutPoints();
+    VectorXi labels = VectorXi::Zero(9);
+
+    double ch = calinskiHarabaszScore(data, labels);
+    double db = daviesBouldinScore(data, labels);
+    EXPECT_TRUE(std::isfinite(ch)) << "calinskiHarabasz = " << ch;
+    EXPECT_TRUE(std::isfinite(db)) << "daviesBouldin = " << db;
+}
+
+TEST(Scores, StillDiscriminatesBetweenPartitions) {
+    ArrayXXd data = spreadOutPoints();
+    VectorXi tight(9), scattered(9);
+    tight    << 0, 0, 0, 1, 1, 1, 2, 2, 2;   // matches the ordering of the data
+    scattered << 0, 1, 2, 0, 1, 2, 0, 1, 2;  // interleaved
+
+    EXPECT_GT(calinskiHarabaszScore(data, tight),
+              calinskiHarabaszScore(data, scattered));
+}
+
+// The default constructor's body used to be statements with no effect, leaving
+// n holding whatever was on the stack.
+TEST(Cluster, DefaultConstructorInitializesCount) {
+    ::Cluster c;
+    EXPECT_EQ(c.getN(), 0);
+}


### PR DESCRIPTION
## Summary

This PR is a 24-commit bugfix and hardening series against `main` (ef21334). It fixes eight undefined-behavior bugs, one inverted algorithm, a memory leak, and several build-system problems, then adds regression tests, updated docs, and a CI workflow. Every fix that touches an algorithm was verified line-by-line against the pinned Python MDANCE reference the C++ sources cite (`bts.py @ 016bd9a`, `helm.py`) **before** the change was written.

Each commit is small, self-contained, and **builds and passes ctest on its own** (verified per-commit in a clean worktree), so the series is bisectable and any subset can be cherry-picked if you prefer to take it piecemeal.

## Highlights by area

**Build system (01–03)**
- The "Setting build type to 'Release'" message never actually called `set()`, so default builds had **no optimization flags at all**.
- `find_package(Eigen3 3.3)` accepted an Eigen too old for the 3.4 slicing API the code uses; now requires 3.4 and links `Eigen3::Eigen`.
- `enable_testing()` moved to the top level (ctest now works from the build root) and the test executable renamed from the reserved name `test` to `mdance_gtests` (CTest name `mdance_tests` unchanged).

**NANI k-means (04–07, 15)**
- Both `KmeansNANI` constructors self-initialized members (`seed(seed)`, `kinit(kinit)`) — the RNG ran on garbage.
- `set_vectorization_threshold` assigned the parameter to itself; the kernel choice in `pairwise_distance` branched on uninitialized memory.
- `run_lloyd` compared against an uninitialized `prevDist` on the first iteration.
- `KinitType::KmeansPP` had no switch case and silently clustered around all-zero centers; it now runs the k-means++ sampler.
- New validation: `kClusters` bounds, user-supplied center shape, and under-selection by percentage-based inits now throw instead of corrupting memory or silently degrading.

**BTS tools (08–11)**
- `repSample` was broken on every path: integer bin width of 0 caused out-of-bounds heap writes, the collection loop never executed (returned uninitialized memory), and the fractional overload always failed. Rewritten to match `rep_sample` in the reference, including `hard_cap=True` as the default.
- `trimOutliers` with the sim-to-medoid criterion **trimmed the frames closest to the medoid** instead of the farthest — the exact opposite of the documented behavior (`np.argsort(values)[-cutoff:]` in the reference). Also fixed an OOB heap read when the medoid fell in the first `nTrimmed` rows, and the wrong object count for non-MSD metrics.
- `diversitySelection` constructed its "percentage too high" error **without throwing it**, and the Random start seed was drawn from the column count (OOB row reads whenever features > frames — the norm for MD data).

**HELM & data structures (12–14, 16)**
- eps-terminated runs recorded a phantom Z-matrix row for the merge that was rejected; the cutoff is now checked before anything is recorded.
- Every `HCTreeNode` leaked (allocated with `new`, never freed; a naive destructor would double-free because merged trees share subtrees). Nodes are now held in `std::shared_ptr`. ASan/LSan confirms: unpatched `main` leaks hundreds of nodes from one HELM test; the branch is leak-free.
- `Cluster`'s default constructor left `n` uninitialized; `calculateCounters` defaulted `wFactor` to `INT_MIN` (meaningless power weights) instead of the reference's fraction weights.

**Modernization & hygiene (17–20)**
- `Eigen::placeholders::all` → `Eigen::all` (deprecated in 3.4, removed in newer Eigen).
- Dead linkage-era declarations removed from `helm.h`; library code now compiles clean under `-Wall -Wextra`; score functions take `const&` instead of deep-copying the trajectory per call.

**Tests, docs, CI (21–24)**
- `test_helm.cpp` no longer `#include`s `scores.cpp` (it only ever linked by archive-resolution luck) and its wrong-depth include paths are fixed.
- 12 new regression tests (suite grows 8 → 20), with expected values computed from a NumPy transcription of the reference — not from the code under test.
- README updated (real prerequisites, current file map); GitHub Actions workflow builds Release + Debug and runs ctest on every PR.

## Behavior changes to review

1. **`trimOutliers(…, isMedoid=true)` results change** — previously it kept outliers and discarded the best-fitting frames. Commit 11; guarded by a test derived from the reference.
2. **`repSample` now returns valid data** (previously uninitialized memory / UB) and its `hardCap` default flips to `true` to match `rep_sample(…, hard_cap=True)`.
3. **New exceptions** for invalid inputs: `diversitySelection(percentage > 100)`, bad `kClusters`, mis-shaped user centers, `repSample(nBins < 1)`.
4. **`getZMatrix()` after eps termination** no longer contains the rejected merge.
5. **`HCTree`/`HCTreeNode` pointer getters/setters** now use `std::shared_ptr` (nothing in-tree used the raw pointers).

## Verification

- 24/24 commits individually configured, built, and passed ctest (GCC 14, Eigen 3.4.0, GoogleTest 1.14).
- Full suite at tip: 20/20 in Release and Debug.
- ASan + UBSan + LSan: zero errors, zero leaks at tip (vs. hundreds of leaked allocations on `main`).
- All pre-existing tests pass unchanged — the Python-derived expected values for NANI and HELM are untouched.

## A note for the divine branch

While reviewing the pre-removal sources, a reproducible crash was found in DIVINE (`splitCluster()` with `refine=true` and the OutlierPair/SplinterPair anchors): the refine block indexes the local `subdata` matrix with **global** frame indices, an out-of-bounds access after any first split. The fix is to index the full `data` matrix instead (`Mat groupA = data(initialMask, Eigen::all);`). It reproduces as an Eigen `IndexedView` assertion in `DivineTest.TestCombinations` on the first OutlierPair × refine combination. Since divine now lives outside `main`, it is not part of this PR — happy to send a separate PR to the divine branch if useful.
