### PR TITLE
Make the build and test suite reproducible on a clean machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG" CACHE STRING "Release flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -DNDEBUG" CACHE STRING "RelWithDebInfo flags" FORCE)
 
+# Enable testing at the top level so `ctest` from the build root discovers tests
+# registered in subdirectories (must precede the add_subdirectory calls below).
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,19 +2,57 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_language(C CXX)
 
-find_package(Eigen3 3.3 REQUIRED)
+# Eigen discovery, in three steps so a fresh checkout builds with no manual setup.
+#
+# 1. Prefer a system Eigen 3.3+. 2. Eigen's own config declares same-major-version
+# compatibility, so a bare "3.3" request is REJECTED by Eigen 5.x even though this
+# code builds and passes its tests against it -- so retry without the floor.
+# 3. If there is no Eigen at all, fetch it. Eigen is header-only, so we populate
+# the sources and declare the imported target ourselves rather than running
+# Eigen's own CMake, which would add its tests, docs and install rules to this
+# build. Set MDANCE_FETCH_EIGEN=OFF to require a system Eigen instead.
+find_package(Eigen3 3.3 QUIET)
+if(NOT Eigen3_FOUND)
+    find_package(Eigen3 QUIET)
+endif()
+option(MDANCE_FETCH_EIGEN "Download Eigen when none is installed" ON)
+if(NOT Eigen3_FOUND)
+    if(NOT MDANCE_FETCH_EIGEN)
+        message(FATAL_ERROR
+            "Eigen was not found and MDANCE_FETCH_EIGEN=OFF. Install Eigen "
+            "(brew install eigen / apt install libeigen3-dev) or set "
+            "MDANCE_FETCH_EIGEN=ON to download it.")
+    endif()
+    message(STATUS "Eigen not found; fetching Eigen 3.4.0")
+    include(FetchContent)
+    FetchContent_Declare(eigen
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG 3.4.0
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+        # Eigen is header-only, and running its CMake would graft its own test
+        # suite onto this build -- measured at 72 extra targets and 957 ctest
+        # entries instead of 2. Pointing SOURCE_SUBDIR at a header directory
+        # with no CMakeLists.txt makes FetchContent populate the sources and
+        # skip add_subdirectory entirely.
+        SOURCE_SUBDIR Eigen)
+    FetchContent_MakeAvailable(eigen)
+    if(NOT TARGET Eigen3::Eigen)
+        add_library(Eigen3::Eigen INTERFACE IMPORTED)
+        target_include_directories(Eigen3::Eigen INTERFACE "${eigen_SOURCE_DIR}")
+    endif()
+endif()
 
 # Create library for tools
 add_library(mdance_tools STATIC
-    tools/bts.cpp 
-    tools/cluster.cpp 
+    tools/bts.cpp
+    tools/cluster.cpp
     tools/hc_utils.cpp
-    tools/esim.cpp 
+    tools/esim.cpp
     tools/scores.cpp
 )
-target_include_directories(mdance_tools PUBLIC 
-    tools
-    ${EIGEN3_INCLUDE_DIRS})
+target_include_directories(mdance_tools PUBLIC tools)
+target_link_libraries(mdance_tools PUBLIC Eigen3::Eigen)
 
 # create library for kmeans
 add_library(mdance_kmeans STATIC 
@@ -39,9 +77,9 @@ target_link_libraries(mdance_helm PUBLIC mdance_tools)
 
 # create main mdance library
 add_library(mdance INTERFACE)
-target_link_libraries(mdance 
-    INTERFACE 
-        mdance_tools 
-        mdance_kmeans 
+target_link_libraries(mdance
+    INTERFACE
+        mdance_tools
+        mdance_kmeans
         mdance_helm
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,62 @@
 cmake_minimum_required(VERSION 3.15)
 
-find_package(GTest REQUIRED)
+# GoogleTest, handled like Eigen in src/CMakeLists.txt: prefer a system install,
+# fetch it if there is none, and if neither is possible skip the C++ test target
+# rather than failing the whole configure -- someone who only wants the library
+# should not need a test framework installed.
+find_package(GTest QUIET)
+option(MDANCE_FETCH_GTEST "Download GoogleTest when none is installed" ON)
+if(NOT GTest_FOUND AND MDANCE_FETCH_GTEST)
+    message(STATUS "GoogleTest not found; fetching v1.15.2")
+    include(FetchContent)
+    # Keep GoogleTest out of this project's install set, and off Windows' CRT
+    # mismatch warning. GoogleTest builds its own tests only with
+    # gtest_build_tests=ON (default OFF), so it adds no ctest entries here.
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.15.2
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE)
+    FetchContent_MakeAvailable(googletest)
+endif()
 
-add_executable(test test_utils.cpp 
-                    test_main.cpp
-                    test_kmeans.cpp
-                    test_helm.cpp
+# Target names differ by source: a modern FindGTest and the fetched build both
+# provide GTest::gtest_main, the fetched build also the bare gtest_main, and an
+# older FindGTest only GTest::Main.
+if(TARGET GTest::gtest_main)
+    set(MDANCE_GTEST_LIBS GTest::gtest GTest::gtest_main)
+elseif(TARGET gtest_main)
+    set(MDANCE_GTEST_LIBS gtest gtest_main)
+elseif(TARGET GTest::Main)
+    set(MDANCE_GTEST_LIBS GTest::GTest GTest::Main)
+else()
+    message(STATUS
+        "GoogleTest unavailable (and MDANCE_FETCH_GTEST=OFF); skipping the C++ "
+        "test target. The library still builds.")
+    return()
+endif()
+
+set(MDANCE_TEST_SOURCES
+    test_utils.cpp
+    test_main.cpp
+    test_kmeans.cpp
+    test_helm.cpp
 )
-target_link_libraries(test PRIVATE 
-                    GTest::GTest
-                    GTest::Main
-                    mdance)
-                    
-enable_testing()
-add_test(NAME mdance_tests COMMAND test)
+
+# Renamed from `test`: a target called `test` shadows the conventional
+# `make test` / ctest driver target that enable_testing() provides.
+add_executable(mdance_gtests ${MDANCE_TEST_SOURCES})
+target_link_libraries(mdance_gtests PRIVATE ${MDANCE_GTEST_LIBS} mdance)
+# GoogleTest 1.15 requires C++14; the rest of this project is C++17.
+target_compile_features(mdance_gtests PRIVATE cxx_std_17)
+
+# The gtest fixtures locate their data as
+#   current_path().parent_path().parent_path() / "tests" / "data"
+# (see the comment in test_kmeans.cpp), which only resolves when the working
+# directory is two levels below the source root -- true for an in-source
+# build/tests/, false for any out-of-source build dir. Running them from
+# tests/data itself makes that expression resolve for every build layout.
+add_test(NAME mdance_tests COMMAND mdance_gtests
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)


### PR DESCRIPTION
This is the first of five related pull requests. Each one is independently
useful and can be reviewed and merged on its own; later ones assume the
earlier ones for verification, not for compilation.

| | PR | What it does |
|---|---|---|
| **1** | **this one** | **Make the build and test suite reproducible** |
| 2 | to follow | Fix latent bugs in existing algorithms |
| 3 | to follow | Add the eQUAL and PRIME ports |
| 4 | to follow | Add a command-line front end |
| 5 | to follow | Add a C API and a VMD/Tcl extension |

This one comes first because until it lands, a reviewer cannot verify any
of the others on a machine that does not already happen to have the right
dependencies in the right places.

## What is wrong today

**A clean checkout does not configure without a system Eigen.** `find_package(Eigen3 3.3 REQUIRED)` is fatal, so there is nothing to build and nothing to test:

```
CMake Error at src/CMakeLists.txt:5 (find_package):
  Could not find a package configuration file provided by "Eigen3"
  (requested version 3.3)
```

**Even with Eigen installed, the 3.3 floor is rejected by a current Eigen.** Eigen's own config file declares same-major-version compatibility, so a request for 3.3 fails against 5.x. That is a version-request problem rather than a source-compatibility one: the code builds and passes against 5.0.1, where `Eigen::placeholders::all` is deprecated rather than removed.

**The test suite passes or fails depending on where you put the build directory.** The gtest fixtures resolve their data as `current_path().parent_path().parent_path() / "tests" / "data"`, which only lands on the real directory when the working directory is exactly two levels below the source root. Same tree, same code:

```
cmake -S . -B build    && (cd build/tests    && ctest)   ->  1/1 passed
cmake -S . -B /tmp/oos && (cd /tmp/oos/tests && ctest)   ->  0% passed
    C++ exception: filesystem error: cannot make canonical path:
    No such file or directory [.../tests/data/sim.csv]
```

## What this changes

- Ask for Eigen 3.3-or-newer first, so a 3.x install still gets a real floor; fall back to whatever Eigen is present; fetch it when there is none. `-DMDANCE_FETCH_EIGEN=OFF` restores the hard requirement, with a message saying what to install.
- Same treatment for GoogleTest, plus: if it is neither installed nor fetchable, skip the test target instead of failing the configure, so someone who only wants the library is not required to have a test framework.
- Run the gtest suite from `tests/data`, which makes that path expression resolve for every build layout.
- Hoist `enable_testing()` to the top level so `ctest` works from the build root, not only from `build/tests`.
- Rename the `test` target to `mdance_gtests`; a target named `test` shadows the conventional ctest driver target.

No behaviour change to any algorithm. CMake only.

## Verification

| | |
|---|---|
| out-of-source, from the build root | 1/1 passed |
| in-source, the route the README documents | 1/1 passed |
| `-DMDANCE_FETCH_EIGEN=OFF` with no system Eigen | fails with an actionable message |
| `-DMDANCE_FETCH_GTEST=OFF` with no system GoogleTest | library builds, test target skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuFWcxHXT5syvbJ6TuhLSa
