### PR TITLE
Fix latent bugs in repSample, Cluster, KMeansNANI and the CH score

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG" CACHE STRING "Release flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O2 -DNDEBUG" CACHE STRING "RelWithDebInfo flags" FORCE)
 
+# Enable testing at the top level so `ctest` from the build root discovers tests
+# registered in subdirectories (must precede the add_subdirectory calls below).
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,19 +2,57 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_language(C CXX)
 
-find_package(Eigen3 3.3 REQUIRED)
+# Eigen discovery, in three steps so a fresh checkout builds with no manual setup.
+#
+# 1. Prefer a system Eigen 3.3+. 2. Eigen's own config declares same-major-version
+# compatibility, so a bare "3.3" request is REJECTED by Eigen 5.x even though this
+# code builds and passes its tests against it -- so retry without the floor.
+# 3. If there is no Eigen at all, fetch it. Eigen is header-only, so we populate
+# the sources and declare the imported target ourselves rather than running
+# Eigen's own CMake, which would add its tests, docs and install rules to this
+# build. Set MDANCE_FETCH_EIGEN=OFF to require a system Eigen instead.
+find_package(Eigen3 3.3 QUIET)
+if(NOT Eigen3_FOUND)
+    find_package(Eigen3 QUIET)
+endif()
+option(MDANCE_FETCH_EIGEN "Download Eigen when none is installed" ON)
+if(NOT Eigen3_FOUND)
+    if(NOT MDANCE_FETCH_EIGEN)
+        message(FATAL_ERROR
+            "Eigen was not found and MDANCE_FETCH_EIGEN=OFF. Install Eigen "
+            "(brew install eigen / apt install libeigen3-dev) or set "
+            "MDANCE_FETCH_EIGEN=ON to download it.")
+    endif()
+    message(STATUS "Eigen not found; fetching Eigen 3.4.0")
+    include(FetchContent)
+    FetchContent_Declare(eigen
+        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+        GIT_TAG 3.4.0
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+        # Eigen is header-only, and running its CMake would graft its own test
+        # suite onto this build -- measured at 72 extra targets and 957 ctest
+        # entries instead of 2. Pointing SOURCE_SUBDIR at a header directory
+        # with no CMakeLists.txt makes FetchContent populate the sources and
+        # skip add_subdirectory entirely.
+        SOURCE_SUBDIR Eigen)
+    FetchContent_MakeAvailable(eigen)
+    if(NOT TARGET Eigen3::Eigen)
+        add_library(Eigen3::Eigen INTERFACE IMPORTED)
+        target_include_directories(Eigen3::Eigen INTERFACE "${eigen_SOURCE_DIR}")
+    endif()
+endif()
 
 # Create library for tools
 add_library(mdance_tools STATIC
-    tools/bts.cpp 
-    tools/cluster.cpp 
+    tools/bts.cpp
+    tools/cluster.cpp
     tools/hc_utils.cpp
-    tools/esim.cpp 
+    tools/esim.cpp
     tools/scores.cpp
 )
-target_include_directories(mdance_tools PUBLIC 
-    tools
-    ${EIGEN3_INCLUDE_DIRS})
+target_include_directories(mdance_tools PUBLIC tools)
+target_link_libraries(mdance_tools PUBLIC Eigen3::Eigen)
 
 # create library for kmeans
 add_library(mdance_kmeans STATIC 
@@ -39,9 +77,9 @@ target_link_libraries(mdance_helm PUBLIC mdance_tools)
 
 # create main mdance library
 add_library(mdance INTERFACE)
-target_link_libraries(mdance 
-    INTERFACE 
-        mdance_tools 
-        mdance_kmeans 
+target_link_libraries(mdance
+    INTERFACE
+        mdance_tools
+        mdance_kmeans
         mdance_helm
 )

--- a/src/cluster/KMeansRex/KMeans.cpp
+++ b/src/cluster/KMeansRex/KMeans.cpp
@@ -153,12 +153,18 @@ void KmeansNANI::reduced_init_Mu(bool isComp) {
 
 void KmeansNANI::init_Mu() {
     vector<Index> idx;
+    if (kClusters > data.rows()) {
+        throw std::runtime_error(
+            "cannot form " + std::to_string(kClusters) + " clusters from " +
+            std::to_string(data.rows()) + " frames.");
+    }
     switch (kinit)
     {
     case MD::KinitType::Random:
         sampleRowsRandom();
         break;
     
+    case MD::KinitType::KmeansPP:
     case MD::KinitType::VanillaKmeansPP:
         sampleRowsPlusPlus();
         break;
@@ -184,6 +190,18 @@ void KmeansNANI::init_Mu() {
     // only take first kClusters centers
     if (centers.rows() > kClusters){
         centers = centers(Eigen::seq(0, kClusters-1), Eigen::placeholders::all).eval();
+    }
+    // The diversity-based seeders draw from `percentage`% of the frames, so on a
+    // short trajectory they can return fewer seeds than kClusters. Downstream,
+    // assignClosest still hands out labels in [0, kClusters) while `centers` has
+    // fewer rows than that, and calcMu indexes off the end -- a segfault in a
+    // release build. Fail with something the caller can act on instead.
+    if (centers.rows() < kClusters){
+        throw std::runtime_error(
+            "initialization produced only " + std::to_string(centers.rows()) +
+            " of the " + std::to_string(kClusters) + " requested centers; raise "
+            "the percentage of frames the seeder samples (--percentage) or ask "
+            "for fewer clusters.");
     }
 }
 
@@ -249,7 +267,7 @@ void KmeansNANI::run_lloyd(int Niter )  {
 }
 
 
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(seed), percentage(percentage) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitType kinit, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(0), percentage(percentage) {
     centers = Mat::Zero(kClusters, data.cols());
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
@@ -258,7 +276,7 @@ KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, MD::KinitTyp
     init_Mu();
     run_lloyd(300);
 }
-KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(kinit), seed(seed), percentage(percentage), centers(centers) {
+KmeansNANI::KmeansNANI(ArrayXXd data, int kClusters, MD::Metric mt, Mat centers, int nAtoms, int percentage, int vectThreshold) : data(data), kClusters(kClusters), mt(mt), nAtoms(nAtoms), kinit(MD::KinitType::StratAll), seed(0), percentage(percentage), centers(centers) {
     dist = Mat::Zero(data.rows(), kClusters);
     labels = Veci::Zero(data.rows());
     set_vectorization_threshold(vectThreshold);

--- a/src/tools/bts.cpp
+++ b/src/tools/bts.cpp
@@ -426,48 +426,64 @@ Index getNewIndexN(const ArrayXXd& data, MD::Metric mt, ArrayXXd& selectedConden
  * Reference: https://github.com/mqcomplab/MDANCE/blob/016bd9aff30d1c2add26b36bfcf64aa665a34a1d/src/mdance/tools/bts.py#L652
 */
 ArrayXi repSample(const ArrayXXd& data, MD::Metric mt, int nAtoms, int nBins, double nSamples, bool hardCap) {
-    if (nSamples < 1) {
-        return repSample(data, mt, nAtoms, nBins, std::round(nSamples * data.rows()), hardCap);
-    }
-    std::cerr << "Cannot sample more than 100\% of the data" << std::endl;
-    return ArrayXi();
+    // nSamples in (0,1) is a fraction of the data; >= 1 is a literal count.
+    int n = (nSamples < 1) ? (int)std::round(nSamples * data.rows())
+                           : (int)std::round(nSamples);
+    return repSample(data, mt, nAtoms, nBins, n, hardCap);
 }
 ArrayXi repSample(const ArrayXXd& data, MD::Metric mt, int nAtoms, int nBins, int nSamples, bool hardCap) {
+    int N = (int)data.rows();
+    if (nSamples > N) nSamples = N;
+    if (nSamples <= 0) return ArrayXi();
+    if (nBins < 1) nBins = 1;
+
     ArrayXd compSims = calculateCompSim(data, nAtoms, mt);
     vector<pair<double,int>> compSimArray;
     compSimArray.reserve(compSims.size());
     for (int i=0; i<compSims.size(); ++i){
-        compSimArray.emplace_back(compSims[i],i);
+        compSimArray.emplace_back(compSims[i], i);
     }
     std::sort(compSimArray.begin(), compSimArray.end());
-    double mi = compSimArray[0].first;
-    double ma = compSimArray[compSims.size()-1].first;
 
+    double mi = compSimArray.front().first;
+    double ma = compSimArray.back().first;
+    double range = ma - mi;
 
-    int step = std::floor((ma - mi) / nBins);
+    // Distribute objects across nBins by complementary-similarity value.
     vector<vector<int>> bins(nBins);
-    int idx=0;
-    for (int i=0; i<compSims.size(); ++i) {
-        if (compSimArray[i].first - mi >= (idx+1)*step) {
-            ++idx;
+    if (range <= 0) {
+        for (auto& p : compSimArray) bins[0].push_back(p.second);
+    } else {
+        double binWidth = range / nBins;
+        for (auto& p : compSimArray) {
+            int b = (int)((p.first - mi) / binWidth);
+            if (b >= nBins) b = nBins - 1;   // the maximum value lands in the last bin
+            if (b < 0) b = 0;
+            bins[b].push_back(p.second);
         }
-        bins[idx].push_back(compSimArray[i].second);
     }
-    VectorXi sampledMols(nSamples);
-    int i=0;
-    int cnt=0;
-    while (sampledMols.size() < nSamples) {
-        for (int b=0; b<bins.size(); ++b) {
-            if (bins[b].size() > i) {
-                sampledMols[cnt] = bins[b][i];
-                ++cnt;
-                if (hardCap && cnt >= nSamples)
-                    break;
+
+    // Round-robin: take one object from each bin per pass until nSamples are
+    // collected or the bins are exhausted.
+    vector<int> sampled;
+    sampled.reserve(nSamples);
+    int round = 0;
+    while ((int)sampled.size() < nSamples) {
+        bool added = false;
+        for (int b = 0; b < nBins && (int)sampled.size() < nSamples; ++b) {
+            if ((int)bins[b].size() > round) {
+                sampled.push_back(bins[b][round]);
+                added = true;
             }
         }
-        ++i;
+        if (!added) break;  // no bin has an object at this depth -> done
+        ++round;
     }
-    return sampledMols;
+    (void)hardCap;  // count is now always capped exactly at nSamples
+
+    ArrayXi out((Index)sampled.size());
+    for (int i = 0; i < (int)sampled.size(); ++i) out(i) = sampled[i];
+    return out;
 }
 
 /* Refine a distance matrix by setting the diagonal to zero and symmetrizing the matrix

--- a/src/tools/cluster.cpp
+++ b/src/tools/cluster.cpp
@@ -1,10 +1,6 @@
 #include "cluster.h"
 
-Cluster::Cluster(){
-    this->indices;
-    this->cSum;
-    this->sqSum;
-    this->n;
+Cluster::Cluster() : n(0) {
 }
 Cluster::Cluster(Veci indices, Vec cSum, Vec sqSum, int n){
     this->indices = indices;

--- a/src/tools/scores.cpp
+++ b/src/tools/scores.cpp
@@ -22,6 +22,12 @@ double calinskiHarabaszScore(const ArrayXXd data, VectorXi labels) {
         }
     }
 
+    // With a single cluster there is no between-cluster dispersion and the ratio
+    // below is 0/0. sklearn rejects k < 2 outright; returning 0 keeps the score a
+    // real number, so callers that serialize it (JSON, Tcl) do not emit `nan`.
+    if (clusters.size() < 2)
+        return 0;
+
     double extraDisp = 0;
     double intraDisp = 0;
     ArrayXd mean = data.colwise().sum() / data.rows();

--- a/src/tools/types.h
+++ b/src/tools/types.h
@@ -11,7 +11,16 @@
 
 #include <Eigen/Dense>
 
-using Eigen::ArrayXXd, Eigen::ArrayXd, Eigen::ArrayXi, Eigen::VectorXi, Eigen::Index, std::vector, std::pair, std::set, std::map, std::string;
+using Eigen::ArrayXXd;
+using Eigen::ArrayXd;
+using Eigen::ArrayXi;
+using Eigen::VectorXi;
+using Eigen::Index;
+using std::vector;
+using std::pair;
+using std::set;
+using std::map;
+using std::string;
 
 typedef ArrayXXd Mat;
 typedef ArrayXd Vec;
@@ -119,6 +128,7 @@ namespace MD {
                 case Metric::SM: return sm;
                 case Metric::SS1: return ss1;
                 case Metric::SS2: return ss2;
+                case Metric::MSD: return 0;
             }
             return 0;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(MDANCE_TEST_SOURCES
     test_main.cpp
     test_kmeans.cpp
     test_helm.cpp
+    test_algorithm_fixes.cpp
 )
 
 # Renamed from `test`: a target called `test` shadows the conventional

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,62 @@
 cmake_minimum_required(VERSION 3.15)
 
-find_package(GTest REQUIRED)
+# GoogleTest, handled like Eigen in src/CMakeLists.txt: prefer a system install,
+# fetch it if there is none, and if neither is possible skip the C++ test target
+# rather than failing the whole configure -- someone who only wants the library
+# should not need a test framework installed.
+find_package(GTest QUIET)
+option(MDANCE_FETCH_GTEST "Download GoogleTest when none is installed" ON)
+if(NOT GTest_FOUND AND MDANCE_FETCH_GTEST)
+    message(STATUS "GoogleTest not found; fetching v1.15.2")
+    include(FetchContent)
+    # Keep GoogleTest out of this project's install set, and off Windows' CRT
+    # mismatch warning. GoogleTest builds its own tests only with
+    # gtest_build_tests=ON (default OFF), so it adds no ctest entries here.
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.15.2
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE)
+    FetchContent_MakeAvailable(googletest)
+endif()
 
-add_executable(test test_utils.cpp 
-                    test_main.cpp
-                    test_kmeans.cpp
-                    test_helm.cpp
+# Target names differ by source: a modern FindGTest and the fetched build both
+# provide GTest::gtest_main, the fetched build also the bare gtest_main, and an
+# older FindGTest only GTest::Main.
+if(TARGET GTest::gtest_main)
+    set(MDANCE_GTEST_LIBS GTest::gtest GTest::gtest_main)
+elseif(TARGET gtest_main)
+    set(MDANCE_GTEST_LIBS gtest gtest_main)
+elseif(TARGET GTest::Main)
+    set(MDANCE_GTEST_LIBS GTest::GTest GTest::Main)
+else()
+    message(STATUS
+        "GoogleTest unavailable (and MDANCE_FETCH_GTEST=OFF); skipping the C++ "
+        "test target. The library still builds.")
+    return()
+endif()
+
+set(MDANCE_TEST_SOURCES
+    test_utils.cpp
+    test_main.cpp
+    test_kmeans.cpp
+    test_helm.cpp
 )
-target_link_libraries(test PRIVATE 
-                    GTest::GTest
-                    GTest::Main
-                    mdance)
-                    
-enable_testing()
-add_test(NAME mdance_tests COMMAND test)
+
+# Renamed from `test`: a target called `test` shadows the conventional
+# `make test` / ctest driver target that enable_testing() provides.
+add_executable(mdance_gtests ${MDANCE_TEST_SOURCES})
+target_link_libraries(mdance_gtests PRIVATE ${MDANCE_GTEST_LIBS} mdance)
+# GoogleTest 1.15 requires C++14; the rest of this project is C++17.
+target_compile_features(mdance_gtests PRIVATE cxx_std_17)
+
+# The gtest fixtures locate their data as
+#   current_path().parent_path().parent_path() / "tests" / "data"
+# (see the comment in test_kmeans.cpp), which only resolves when the working
+# directory is two levels below the source root -- true for an in-source
+# build/tests/, false for any out-of-source build dir. Running them from
+# tests/data itself makes that expression resolve for every build layout.
+add_test(NAME mdance_tests COMMAND mdance_gtests
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)

--- a/tests/test_algorithm_fixes.cpp
+++ b/tests/test_algorithm_fixes.cpp
@@ -1,0 +1,137 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <set>
+
+#include "../src/tools/bts.h"
+#include "../src/tools/cluster.h"
+#include "../src/tools/scores.h"
+#include "../src/cluster/KMeansRex/KMeans.h"
+
+namespace {
+
+// `nBlobs` tight groups spread `spacing` apart, `perBlob` rows each.
+ArrayXXd makeBlobs(int nBlobs, int perBlob, int ncols, double spacing,
+                   double offset = 0.0) {
+    ArrayXXd data(nBlobs * perBlob, ncols);
+    for (int b = 0; b < nBlobs; ++b) {
+        for (int i = 0; i < perBlob; ++i) {
+            for (int j = 0; j < ncols; ++j) {
+                data(b * perBlob + i, j) = offset + b * spacing + (i % 3) * 0.01;
+            }
+        }
+    }
+    return data;
+}
+
+}  // namespace
+
+// repSample's fill loop tested `sampledMols.size() < nSamples` against a VectorXi
+// that was already sized to nSamples -- a constant-false condition, so the loop
+// never ran and the function returned an UNINITIALIZED vector. Every caller got
+// garbage frame indices.
+TEST(AlgorithmFixes, RepSampleReturnsRealFrameIndices) {
+    ArrayXXd data = makeBlobs(4, 10, 6, 25.0);
+    const int N = (int)data.rows();
+
+    ArrayXi picked = repSample(data, MD::Metric::MSD, 2, 5, 12, true);
+
+    ASSERT_EQ(picked.size(), 12);
+    std::set<int> distinct;
+    for (int i = 0; i < picked.size(); ++i) {
+        EXPECT_GE(picked(i), 0) << "index " << i;
+        EXPECT_LT(picked(i), N) << "index " << i;
+        distinct.insert(picked(i));
+    }
+    EXPECT_EQ((int)distinct.size(), 12) << "sampled the same frame twice";
+}
+
+// The bin width was std::floor((max - min) / nBins), which truncates to 0
+// whenever the complementary-similarity range is narrower than nBins. Every row
+// then advanced the bin cursor and it ran off the end of the bin vector.
+TEST(AlgorithmFixes, RepSampleHandlesDegenerateRange) {
+    ArrayXXd data = ArrayXXd::Constant(30, 4, 7.0);   // identical rows -> zero range
+
+    ArrayXi picked = repSample(data, MD::Metric::MSD, 1, 10, 8, true);
+
+    ASSERT_LE(picked.size(), 8);
+    for (int i = 0; i < picked.size(); ++i) {
+        EXPECT_GE(picked(i), 0);
+        EXPECT_LT(picked(i), 30);
+    }
+}
+
+TEST(AlgorithmFixes, RepSampleCapsAtDatasetSize) {
+    ArrayXXd data = makeBlobs(2, 5, 3, 40.0);         // 10 frames
+    ArrayXi picked = repSample(data, MD::Metric::MSD, 1, 4, 500, true);
+    EXPECT_LE(picked.size(), 10);
+    EXPECT_GT(picked.size(), 0);
+}
+
+// The default constructor's body was four statements with no effect, leaving n
+// with whatever happened to be on the stack.
+TEST(AlgorithmFixes, ClusterDefaultConstructorInitializesCount) {
+    Cluster c;
+    EXPECT_EQ(c.getN(), 0);
+}
+
+// A single cluster makes the Calinski-Harabasz ratio 0/0. The NaN propagated
+// into every serialized result.
+TEST(AlgorithmFixes, ScoresAreFiniteForSingleCluster) {
+    ArrayXXd data = makeBlobs(1, 9, 4, 0.0);
+    VectorXi labels = VectorXi::Zero(9);
+
+    double ch = calinskiHarabaszScore(data, labels);
+    double db = daviesBouldinScore(data, labels);
+    EXPECT_TRUE(std::isfinite(ch)) << "calinskiHarabasz = " << ch;
+    EXPECT_TRUE(std::isfinite(db)) << "daviesBouldin = " << db;
+}
+
+// init_Mu truncated when the seeder returned MORE centers than requested but not
+// when it returned fewer. assignClosest then handed out labels in [0, k) against
+// a shorter `centers`, and calcMu indexed past the end -- a segfault in a release
+// build, on any trajectory short enough that percentage% of it is under k.
+TEST(AlgorithmFixes, KmeansRejectsUnderproducedSeeds) {
+    ArrayXXd data = makeBlobs(3, 3, 4, 50.0);        // 9 frames; 10% of 9 -> 0 seeds
+    EXPECT_THROW(KmeansNANI(data, 3, MD::Metric::MSD, MD::KinitType::StratAll, 1, 10),
+                 std::runtime_error);
+    // Sampling the whole trajectory gives the seeder enough to work with.
+    EXPECT_NO_THROW(KmeansNANI(data, 3, MD::Metric::MSD, MD::KinitType::StratAll, 1, 100));
+}
+
+TEST(AlgorithmFixes, KmeansRejectsMoreClustersThanFrames) {
+    ArrayXXd data = makeBlobs(3, 3, 4, 50.0);        // 9 frames
+    EXPECT_THROW(KmeansNANI(data, 20, MD::Metric::MSD, MD::KinitType::StratAll, 1, 100),
+                 std::runtime_error);
+}
+
+// KinitType::KmeansPP was absent from init_Mu's switch, so `centers` stayed at
+// its Mat::Zero initialization. Every frame is then equidistant from every
+// center, assignClosest puts them all in cluster 0, and the run collapses to a
+// single cluster whatever k was asked for.
+TEST(AlgorithmFixes, KmeansPPSeedsFromTheData) {
+    // Offset well away from the origin so a zeroed center is never the nearest
+    // point for anything -- otherwise Lloyd drifts back to a sane partition and
+    // masks the uninitialized centers.
+    ArrayXXd data = makeBlobs(3, 8, 5, 1000.0, 10000.0);
+
+    KmeansNANI km(data, 3, MD::Metric::MSD, MD::KinitType::KmeansPP, 1, 100);
+    Veci labels = km.getLabels();
+
+    std::set<int> distinct;
+    for (int i = 0; i < labels.size(); ++i) distinct.insert(labels(i));
+    EXPECT_EQ((int)distinct.size(), 3) << "collapsed to " << distinct.size() << " cluster(s)";
+}
+
+// Both constructors initialized `seed` from itself, so the Mersenne Twister was
+// seeded with an indeterminate value and the randomized initializers were not
+// reproducible between runs of the same input.
+TEST(AlgorithmFixes, RandomizedInitializationIsReproducible) {
+    ArrayXXd data = makeBlobs(3, 8, 5, 1000.0, 10000.0);
+
+    Veci first  = KmeansNANI(data, 3, MD::Metric::MSD, MD::KinitType::KmeansPP, 1, 100).getLabels();
+    Veci second = KmeansNANI(data, 3, MD::Metric::MSD, MD::KinitType::KmeansPP, 1, 100).getLabels();
+
+    ASSERT_EQ(first.size(), second.size());
+    EXPECT_TRUE((first.array() == second.array()).all()) << "same input, different labels";
+}


### PR DESCRIPTION
Second of five related pull requests.

| | PR | What it does |
|---|---|---|
| 1 | #47 | Make the build and test suite reproducible |
| **2** | **this one** | **Fix latent bugs in existing algorithms** |
| 3 | to follow | Add the eQUAL and PRIME ports |
| 4 | to follow | Add a command-line front end |
| 5 | to follow | Add a C API and a VMD/Tcl extension |

> **Stacked on #47.** Until that merges, the diff below also contains its
> commit. The isolated diff for this PR alone is
> [`pr1-build-reproducibility...pr2-algorithm-fixes`](https://github.com/diegoenry/CPP-MDANCE/compare/pr1-build-reproducibility...pr2-algorithm-fixes).
> It depends on #47 only for the test suite to be runnable; the fixes
> themselves compile against `main` as it stands.

Five defects in existing code, each with a regression test. They are
independent of one another and of anything else in this series; I found
them while building front ends against the library.

## `repSample` returns uninitialized memory

The fill loop tests `sampledMols.size() < nSamples` against a `VectorXi` that was already sized to `nSamples` — a constant-false condition. The loop never runs, and the function returns whatever was on the heap as frame indices.

The bin width is also `std::floor((max - min) / nBins)`, which truncates to 0 whenever the complementary-similarity range is narrower than `nBins`. Every row then advances the bin cursor and it runs off the end of the bin vector.

Both are reachable from the default arguments — the first three tests in `tests/test_algorithm_fixes.cpp` segfault against current `main`. Rewritten with real bin widths and a bounded round-robin, capped at the dataset size.

(The `double`-typed overload also rejected every literal count with *"Cannot sample more than 100% of the data"* before sampling anything. It is not declared in `bts.h`, so nothing outside that translation unit could reach it.)

## `KmeansNANI::init_Mu` can leave fewer centers than clusters

It truncates when the initializer returns *more* centers than requested, but not when it returns fewer. The diversity-based seeders draw from `percentage`% of the frames, so on a short trajectory they produce fewer seeds than `kClusters` — `assignClosest` then hands out labels in `[0, kClusters)` against a shorter `centers`, and `calcMu` indexes past the end.

That is a segfault in a release build, not an assertion. A 9-frame input with `k=3` crashes at the default percentage. Asking for more clusters than frames is now refused up front too.

## `KinitType::KmeansPP` is missing from the switch

It falls through `init_Mu` unhandled, so `centers` stays at its `Mat::Zero` initialization and the run collapses onto a single cluster whatever `k` was asked for.

## Both `KmeansNANI` constructors self-initialize `seed`

`seed(seed)` and `kinit(kinit)` read the members being initialized, so the Mersenne Twister is seeded with an indeterminate value. Fixed to 0, which also makes the randomized initializers reproducible between runs of the same input.

## `Cluster()` and the Calinski-Harabasz score

The default constructor's body is four statements with no effect, leaving `n` indeterminate. And a single-cluster partition makes the CH ratio 0/0, so the score comes back `nan` — which then propagates into anything that serializes it.

Also splits the comma-chained using-declaration in `types.h` and adds the missing `Metric::MSD` case to `Indices::getIndex`, which `-Wswitch` warns about:

```
types.h:111:19: warning: enumeration value 'MSD' not handled in switch [-Wswitch]
```

## Verification

`tests/test_algorithm_fixes.cpp` adds 9 tests. Run against unfixed sources, 7 of them fail — three by segfault, four by assertion — and all pass with the fixes applied.

The last one, `RandomizedInitializationIsReproducible`, asserts a real property but is **not** a detector for the `seed(seed)` bug: an indeterminate value tends to repeat within a single process, so it passes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuFWcxHXT5syvbJ6TuhLSa
